### PR TITLE
feat(user): Add TotpSecret and SubscriptionTierId to User model

### DIFF
--- a/PassManAPI/Controllers/AuthController.cs
+++ b/PassManAPI/Controllers/AuthController.cs
@@ -369,7 +369,8 @@ public class AuthController : ControllerBase
             user.CreatedAt,
             user.UpdatedAt,
             user.LastLoginAt,
-            user.EncryptedVaultKey
+            user.EncryptedVaultKey,
+            user.SubscriptionTierId
         );
 
     private static UserProfileResponse ToProfile(Managers.UserResponse user) =>
@@ -381,7 +382,8 @@ public class AuthController : ControllerBase
             user.CreatedAt,
             user.UpdatedAt,
             user.LastLoginAt,
-            user.EncryptedVaultKey
+            user.EncryptedVaultKey,
+            user.SubscriptionTierId
         );
 
     private async Task<(bool Success, string? Error)> AddUserToRoleAsync(User user, string roleName)

--- a/PassManAPI/DTOs/UserDtos.cs
+++ b/PassManAPI/DTOs/UserDtos.cs
@@ -65,7 +65,8 @@ public record UserProfileResponse(
     DateTime CreatedAt,
     DateTime? UpdatedAt,
     DateTime? LastLoginAt,
-    string? EncryptedVaultKey
+    string? EncryptedVaultKey,
+    Guid? SubscriptionTierId
 );
 
 /// <summary>

--- a/PassManAPI/Managers/UserManager.cs
+++ b/PassManAPI/Managers/UserManager.cs
@@ -28,7 +28,8 @@ public record UserResponse(
     DateTime CreatedAt,
     DateTime? UpdatedAt,
     DateTime? LastLoginAt,
-    string? EncryptedVaultKey
+    string? EncryptedVaultKey,
+    Guid? SubscriptionTierId
 );
 
 public class UserOperationResult<T>
@@ -208,7 +209,8 @@ public class UserManager
             user.CreatedAt,
             user.UpdatedAt,
             user.LastLoginAt,
-            user.EncryptedVaultKey
+            user.EncryptedVaultKey,
+            user.SubscriptionTierId
         );
 }
 

--- a/PassManAPI/Migrations/20260117204813_AddTotpSecretAndSubscriptionTierIdToUser.Designer.cs
+++ b/PassManAPI/Migrations/20260117204813_AddTotpSecretAndSubscriptionTierIdToUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PassManAPI.Data;
 
@@ -11,9 +12,11 @@ using PassManAPI.Data;
 namespace PassManAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260117204813_AddTotpSecretAndSubscriptionTierIdToUser")]
+    partial class AddTotpSecretAndSubscriptionTierIdToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/PassManAPI/Migrations/20260117204813_AddTotpSecretAndSubscriptionTierIdToUser.cs
+++ b/PassManAPI/Migrations/20260117204813_AddTotpSecretAndSubscriptionTierIdToUser.cs
@@ -11,46 +11,6 @@ namespace PassManAPI.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "CreatedAt",
-                table: "Vaults",
-                type: "datetime(6)",
-                nullable: false,
-                defaultValueSql: "CURRENT_TIMESTAMP",
-                oldClrType: typeof(DateTime),
-                oldType: "datetime(6)",
-                oldDefaultValueSql: "CURRENT_TIMESTAMP(6)");
-
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "CreatedAt",
-                table: "Credentials",
-                type: "datetime(6)",
-                nullable: false,
-                defaultValueSql: "CURRENT_TIMESTAMP",
-                oldClrType: typeof(DateTime),
-                oldType: "datetime(6)",
-                oldDefaultValueSql: "CURRENT_TIMESTAMP(6)");
-
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "Timestamp",
-                table: "AuditLogs",
-                type: "datetime(6)",
-                nullable: false,
-                defaultValueSql: "CURRENT_TIMESTAMP",
-                oldClrType: typeof(DateTime),
-                oldType: "datetime(6)",
-                oldDefaultValueSql: "CURRENT_TIMESTAMP(6)");
-
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "CreatedAt",
-                table: "AspNetUsers",
-                type: "datetime(6)",
-                nullable: false,
-                defaultValueSql: "CURRENT_TIMESTAMP",
-                oldClrType: typeof(DateTime),
-                oldType: "datetime(6)",
-                oldDefaultValueSql: "CURRENT_TIMESTAMP(6)");
-
             migrationBuilder.AddColumn<Guid>(
                 name: "SubscriptionTierId",
                 table: "AspNetUsers",

--- a/PassManAPI/Migrations/20260117204813_AddTotpSecretAndSubscriptionTierIdToUser.cs
+++ b/PassManAPI/Migrations/20260117204813_AddTotpSecretAndSubscriptionTierIdToUser.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PassManAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTotpSecretAndSubscriptionTierIdToUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedAt",
+                table: "Vaults",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP",
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP(6)");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedAt",
+                table: "Credentials",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP",
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP(6)");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Timestamp",
+                table: "AuditLogs",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP",
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP(6)");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedAt",
+                table: "AspNetUsers",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP",
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP(6)");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "SubscriptionTierId",
+                table: "AspNetUsers",
+                type: "char(36)",
+                nullable: true,
+                collation: "ascii_general_ci");
+
+            migrationBuilder.AddColumn<string>(
+                name: "TotpSecret",
+                table: "AspNetUsers",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SubscriptionTierId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "TotpSecret",
+                table: "AspNetUsers");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedAt",
+                table: "Vaults",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP(6)",
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedAt",
+                table: "Credentials",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP(6)",
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Timestamp",
+                table: "AuditLogs",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP(6)",
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedAt",
+                table: "AspNetUsers",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP(6)",
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldDefaultValueSql: "CURRENT_TIMESTAMP");
+        }
+    }
+}

--- a/PassManAPI/Models/User.cs
+++ b/PassManAPI/Models/User.cs
@@ -15,6 +15,16 @@ namespace PassManAPI.Models
         public DateTime? LastLoginAt { get; set; }
         public string? EncryptedVaultKey { get; set; }
 
+        /// <summary>
+        /// Base32-encoded TOTP secret for 2FA authentication.
+        /// </summary>
+        public string? TotpSecret { get; set; }
+
+        /// <summary>
+        /// Link to the user's subscription tier.
+        /// </summary>
+        public Guid? SubscriptionTierId { get; set; }
+
         // Navigation properties
         public virtual ICollection<Vault> Vaults { get; set; } = new List<Vault>();
         public virtual ICollection<VaultShare> SharedVaults { get; set; } = new List<VaultShare>();


### PR DESCRIPTION
## Summary
Closes #78, Part of #68

This PR adds two new properties to the `User` model as specified in the UML design:

### Changes Made

1. **User Model (`PassManAPI/Models/User.cs`)**:
   - Added `TotpSecret: string?` - Base32-encoded TOTP secret for 2FA authentication
   - Added `SubscriptionTierId: Guid?` - Link to the user's subscription tier

2. **DTOs (`PassManAPI/DTOs/UserDtos.cs`)**:
   - Added `SubscriptionTierId` to `UserProfileResponse` record
   - **Note**: `TotpSecret` is intentionally NOT exposed in DTOs for security reasons

3. **UserManager (`PassManAPI/Managers/UserManager.cs`)**:
   - Updated `UserResponse` record to include `SubscriptionTierId`
   - Updated `ToResponse()` method to map the new field

4. **AuthController (`PassManAPI/Controllers/AuthController.cs`)**:
   - Updated both `ToProfile()` methods to include `SubscriptionTierId`

5. **EF Core Migration**:
   - Created migration `AddTotpSecretAndSubscriptionTierIdToUser` to add the new columns

### Security Considerations
- `TotpSecret` is stored in the database but never exposed through API responses
- This follows best practices for sensitive authentication secrets

### Testing
- All 21 existing integration tests pass ✅

### Notes
- `SubscriptionTierId` is currently a standalone `Guid?` without a FK constraint
- The FK relationship will be added when issue #107 (Create SubscriptionTier model) is implemented