### PR TITLE
feat: Add UserController with CRUD endpoints

### DIFF
--- a/PassManAPI.Tests/UserEndpointsTests.cs
+++ b/PassManAPI.Tests/UserEndpointsTests.cs
@@ -1,0 +1,263 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using PassManAPI.DTOs;
+using Xunit;
+
+namespace PassManAPI.Tests;
+
+public class UserEndpointsTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public UserEndpointsTests(TestWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Get_Own_Profile_Returns_Success()
+    {
+        // Arrange
+        var user = await RegisterAsync("user-get-own@test.local");
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/user/{user.User.Id}");
+        request.Headers.Add("X-UserId", user.User.Id.ToString());
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var profile = await response.Content.ReadFromJsonAsync<UserProfileResponse>();
+        profile.Should().NotBeNull();
+        profile!.Email.Should().Be("user-get-own@test.local");
+    }
+
+    [Fact]
+    public async Task Get_Other_User_Without_Permission_Returns_Forbidden()
+    {
+        // Arrange
+        var user1 = await RegisterAsync("user-forbidden-1@test.local");
+        var user2 = await RegisterAsync("user-forbidden-2@test.local");
+
+        // Act - user1 tries to view user2's profile
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/user/{user2.User.Id}");
+        request.Headers.Add("X-UserId", user1.User.Id.ToString());
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Get_Nonexistent_User_Returns_NotFound()
+    {
+        // Arrange
+        var user = await RegisterAsync("user-get-nonexistent@test.local");
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/user/999999");
+        request.Headers.Add("X-UserId", user.User.Id.ToString());
+        // This will return Forbidden because they're not admin and not user 999999
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Update_Own_Profile_Returns_Success()
+    {
+        // Arrange
+        var user = await RegisterAsync("user-update-own@test.local");
+        var updateRequest = new { email = "user-update-own-new@test.local", userName = "UpdatedUser" };
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/user/{user.User.Id}")
+        {
+            Content = JsonContent.Create(updateRequest)
+        };
+        request.Headers.Add("X-UserId", user.User.Id.ToString());
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var profile = await response.Content.ReadFromJsonAsync<UserProfileResponse>();
+        profile.Should().NotBeNull();
+        profile!.UserName.Should().Be("UpdatedUser");
+    }
+
+    [Fact]
+    public async Task Update_Other_User_Without_Permission_Returns_Forbidden()
+    {
+        // Arrange
+        var user1 = await RegisterAsync("user-update-forbidden-1@test.local");
+        var user2 = await RegisterAsync("user-update-forbidden-2@test.local");
+        var updateRequest = new { email = "hacker@test.local", userName = "Hacker" };
+
+        // Act - user1 tries to update user2's profile
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/user/{user2.User.Id}")
+        {
+            Content = JsonContent.Create(updateRequest)
+        };
+        request.Headers.Add("X-UserId", user1.User.Id.ToString());
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Delete_Own_Account_Returns_NoContent()
+    {
+        // Arrange
+        var user = await RegisterAsync("user-delete-own@test.local");
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/user/{user.User.Id}");
+        request.Headers.Add("X-UserId", user.User.Id.ToString());
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Verify user is deleted - trying to get profile should fail
+        var getRequest = new HttpRequestMessage(HttpMethod.Get, $"/api/user/{user.User.Id}");
+        getRequest.Headers.Add("X-UserId", user.User.Id.ToString());
+        var getResponse = await _client.SendAsync(getRequest);
+        getResponse.StatusCode.Should().BeOneOf(HttpStatusCode.NotFound, HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Delete_Other_User_Without_Permission_Returns_Forbidden()
+    {
+        // Arrange
+        var user1 = await RegisterAsync("user-delete-forbidden-1@test.local");
+        var user2 = await RegisterAsync("user-delete-forbidden-2@test.local");
+
+        // Act - user1 tries to delete user2's account
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/user/{user2.User.Id}");
+        request.Headers.Add("X-UserId", user1.User.Id.ToString());
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Get_User_Vaults_Returns_Own_Vaults()
+    {
+        // Arrange
+        var user = await RegisterAsync("user-vaults@test.local");
+
+        // Create a vault first (note: vault name must only contain letters, numbers, spaces, hyphens, underscores)
+        var createVault = new { name = "User Test Vault", description = "test vault", userId = user.User.Id };
+        var createVaultRequest = new HttpRequestMessage(HttpMethod.Post, "/api/vaults")
+        {
+            Content = JsonContent.Create(createVault)
+        };
+        createVaultRequest.Headers.Add("X-UserId", user.User.Id.ToString());
+        var createVaultResponse = await _client.SendAsync(createVaultRequest);
+        createVaultResponse.EnsureSuccessStatusCode();
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/user/{user.User.Id}/vaults");
+        request.Headers.Add("X-UserId", user.User.Id.ToString());
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var vaults = await response.Content.ReadFromJsonAsync<List<VaultSummaryDto>>();
+        vaults.Should().NotBeNull();
+        vaults!.Should().ContainSingle(v => v.Name == "User Test Vault");
+    }
+
+    [Fact]
+    public async Task Get_Other_User_Vaults_Without_Permission_Returns_Forbidden()
+    {
+        // Arrange
+        var user1 = await RegisterAsync("user-vaults-forbidden-1@test.local");
+        var user2 = await RegisterAsync("user-vaults-forbidden-2@test.local");
+
+        // Act - user1 tries to view user2's vaults
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/user/{user2.User.Id}/vaults");
+        request.Headers.Add("X-UserId", user1.User.Id.ToString());
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Get_User_Tags_Returns_Own_Tags()
+    {
+        // Arrange
+        var user = await RegisterAsync("user-tags@test.local");
+
+        // Create a tag first
+        var createTag = new { name = "TestTag" };
+        var createTagRequest = new HttpRequestMessage(HttpMethod.Post, "/api/tags")
+        {
+            Content = JsonContent.Create(createTag)
+        };
+        createTagRequest.Headers.Add("X-UserId", user.User.Id.ToString());
+        var createTagResponse = await _client.SendAsync(createTagRequest);
+        createTagResponse.EnsureSuccessStatusCode();
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/user/{user.User.Id}/tags");
+        request.Headers.Add("X-UserId", user.User.Id.ToString());
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var tags = await response.Content.ReadFromJsonAsync<List<TagDto>>();
+        tags.Should().NotBeNull();
+        tags!.Should().ContainSingle(t => t.Name == "TestTag");
+    }
+
+    [Fact]
+    public async Task Get_Other_User_Tags_Without_Permission_Returns_Forbidden()
+    {
+        // Arrange
+        var user1 = await RegisterAsync("user-tags-forbidden-1@test.local");
+        var user2 = await RegisterAsync("user-tags-forbidden-2@test.local");
+
+        // Act - user1 tries to view user2's tags
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/user/{user2.User.Id}/tags");
+        request.Headers.Add("X-UserId", user1.User.Id.ToString());
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_Request_Returns_Unauthorized()
+    {
+        // Act - no X-UserId header
+        var response = await _client.GetAsync("/api/user/1");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task<AuthResponse> RegisterAsync(string email)
+    {
+        var request = new RegisterRequest
+        {
+            Email = email,
+            Password = "Password1!",
+            ConfirmPassword = "Password1!",
+            UserName = email.Split('@')[0],
+            PhoneNumber = "1234567890"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/auth/register", request);
+        response.EnsureSuccessStatusCode();
+        var payload = await response.Content.ReadFromJsonAsync<AuthResponse>();
+        return payload!;
+    }
+
+    private record VaultSummaryDto(int Id, string Name, string? Description, DateTime CreatedAt);
+}

--- a/PassManAPI/Controllers/UserController.cs
+++ b/PassManAPI/Controllers/UserController.cs
@@ -1,0 +1,299 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PassManAPI.Data;
+using PassManAPI.DTOs;
+using PassManAPI.Managers;
+using PassManAPI.Models;
+
+namespace PassManAPI.Controllers;
+
+/// <summary>
+/// Controller for administrative user management.
+/// Separates user CRUD operations from authentication (AuthController).
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class UserController : ControllerBase
+{
+    private readonly UserManager _userManager;
+    private readonly ApplicationDbContext _db;
+
+    public UserController(UserManager userManager, ApplicationDbContext db)
+    {
+        _userManager = userManager;
+        _db = db;
+    }
+
+    /// <summary>
+    /// Lists all users (admin only).
+    /// </summary>
+    /// <response code="200">Returns the list of users.</response>
+    /// <response code="403">If the user doesn't have UserManage permission.</response>
+    [HttpGet]
+    [Authorize(Policy = PermissionConstants.UserManage)]
+    [ProducesResponseType(typeof(IEnumerable<UserProfileResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<IEnumerable<UserProfileResponse>>> GetAllUsers()
+    {
+        var users = await _db.Users
+            .AsNoTracking()
+            .OrderBy(u => u.Email)
+            .ToListAsync();
+
+        var response = users.Select(ToProfile);
+        return Ok(response);
+    }
+
+    /// <summary>
+    /// Gets a specific user by ID.
+    /// </summary>
+    /// <param name="id">The user ID.</param>
+    /// <response code="200">User found.</response>
+    /// <response code="403">If the user doesn't have permission to view this user.</response>
+    /// <response code="404">User not found.</response>
+    [HttpGet("{id:int}")]
+    [ProducesResponseType(typeof(UserProfileResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<UserProfileResponse>> GetUser(int id)
+    {
+        if (!TryGetCurrentUserId(out var currentUserId))
+        {
+            return Unauthorized();
+        }
+
+        // Users can view their own profile, or admins can view any profile
+        if (currentUserId != id && !HasPermission(PermissionConstants.UserManage))
+        {
+            return Forbid();
+        }
+
+        var result = await _userManager.GetUserByIdAsync(id);
+        if (!result.Success || result.Data is null)
+        {
+            return NotFound(result.Error ?? "User not found.");
+        }
+
+        return Ok(ToProfile(result.Data));
+    }
+
+    /// <summary>
+    /// Updates a user's profile.
+    /// </summary>
+    /// <param name="id">The user ID.</param>
+    /// <param name="request">The update request.</param>
+    /// <response code="200">User updated.</response>
+    /// <response code="400">Invalid request.</response>
+    /// <response code="403">If the user doesn't have permission to update this user.</response>
+    /// <response code="404">User not found.</response>
+    [HttpPut("{id:int}")]
+    [ProducesResponseType(typeof(UserProfileResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<UserProfileResponse>> UpdateUser(int id, [FromBody] UpdateProfileRequest request)
+    {
+        if (!TryGetCurrentUserId(out var currentUserId))
+        {
+            return Unauthorized();
+        }
+
+        // Users can update their own profile, or admins can update any profile
+        if (currentUserId != id && !HasPermission(PermissionConstants.UserManage))
+        {
+            return Forbid();
+        }
+
+        var updateRequest = new UpdateUserRequest(
+            request.Email,
+            request.UserName,
+            request.PhoneNumber,
+            request.EncryptedVaultKey
+        );
+
+        var result = await _userManager.UpdateUserAsync(id, updateRequest);
+        if (!result.Success || result.Data is null)
+        {
+            if (result.Error?.Contains("not found") == true)
+            {
+                return NotFound(result.Error);
+            }
+            return BadRequest(result.Error ?? "Update failed.");
+        }
+
+        await LogAuditAsync(AuditAction.UserPasswordChanged, currentUserId, id, "Profile updated");
+        return Ok(ToProfile(result.Data));
+    }
+
+    /// <summary>
+    /// Deletes a user account.
+    /// </summary>
+    /// <param name="id">The user ID.</param>
+    /// <response code="204">User deleted.</response>
+    /// <response code="403">If the user doesn't have permission to delete this user.</response>
+    /// <response code="404">User not found.</response>
+    [HttpDelete("{id:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteUser(int id)
+    {
+        if (!TryGetCurrentUserId(out var currentUserId))
+        {
+            return Unauthorized();
+        }
+
+        // Users can delete their own account, or admins can delete any account
+        if (currentUserId != id && !HasPermission(PermissionConstants.UserManage))
+        {
+            return Forbid();
+        }
+
+        var result = await _userManager.DeleteUserAsync(id);
+        if (!result.Success)
+        {
+            return NotFound(result.Error ?? "User not found.");
+        }
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Gets all vaults owned by or shared with a user.
+    /// </summary>
+    /// <param name="id">The user ID.</param>
+    /// <response code="200">Returns the list of vaults.</response>
+    /// <response code="403">If the user doesn't have permission to view this user's vaults.</response>
+    /// <response code="404">User not found.</response>
+    [HttpGet("{id:int}/vaults")]
+    [ProducesResponseType(typeof(IEnumerable<VaultSummaryDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<IEnumerable<VaultSummaryDto>>> GetUserVaults(int id)
+    {
+        if (!TryGetCurrentUserId(out var currentUserId))
+        {
+            return Unauthorized();
+        }
+
+        // Users can view their own vaults, or admins can view any user's vaults
+        if (currentUserId != id && !HasPermission(PermissionConstants.UserManage))
+        {
+            return Forbid();
+        }
+
+        var userExists = await _db.Users.AnyAsync(u => u.Id == id);
+        if (!userExists)
+        {
+            return NotFound("User not found.");
+        }
+
+        var vaults = await _db.Vaults
+            .AsNoTracking()
+            .Where(v => v.UserId == id && !v.IsDeleted)
+            .Select(v => new VaultSummaryDto(v.Id, v.Name, v.Description, v.CreatedAt))
+            .ToListAsync();
+
+        return Ok(vaults);
+    }
+
+    /// <summary>
+    /// Gets all tags owned by a user.
+    /// </summary>
+    /// <param name="id">The user ID.</param>
+    /// <response code="200">Returns the list of tags.</response>
+    /// <response code="403">If the user doesn't have permission to view this user's tags.</response>
+    /// <response code="404">User not found.</response>
+    [HttpGet("{id:int}/tags")]
+    [ProducesResponseType(typeof(IEnumerable<TagDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<IEnumerable<TagDto>>> GetUserTags(int id)
+    {
+        if (!TryGetCurrentUserId(out var currentUserId))
+        {
+            return Unauthorized();
+        }
+
+        // Users can view their own tags, or admins can view any user's tags
+        if (currentUserId != id && !HasPermission(PermissionConstants.UserManage))
+        {
+            return Forbid();
+        }
+
+        var userExists = await _db.Users.AnyAsync(u => u.Id == id);
+        if (!userExists)
+        {
+            return NotFound("User not found.");
+        }
+
+        var tags = await _db.Tags
+            .AsNoTracking()
+            .Where(t => t.UserId == id)
+            .Select(t => new TagDto(t.Id, t.Name))
+            .ToListAsync();
+
+        return Ok(tags);
+    }
+
+    // Helper methods
+    private bool TryGetCurrentUserId(out int userId)
+    {
+        userId = 0;
+        var claim = User.FindFirst(ClaimTypes.NameIdentifier);
+        return claim != null && int.TryParse(claim.Value, out userId);
+    }
+
+    private bool HasPermission(string permission)
+    {
+        return User.Claims.Any(c => c.Type == PermissionConstants.ClaimType && c.Value == permission);
+    }
+
+    private async Task LogAuditAsync(AuditAction action, int actorUserId, int targetUserId, string? details = null)
+    {
+        _db.AuditLogs.Add(new AuditLog
+        {
+            Action = action,
+            EntityType = "User",
+            EntityId = targetUserId,
+            UserId = actorUserId,
+            Details = details ?? $"User {actorUserId} performed {action} on user {targetUserId}",
+            Timestamp = DateTime.UtcNow
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    private static UserProfileResponse ToProfile(User user) =>
+        new(
+            user.Id,
+            user.Email ?? string.Empty,
+            user.UserName,
+            user.PhoneNumber,
+            user.CreatedAt,
+            user.UpdatedAt,
+            user.LastLoginAt,
+            user.EncryptedVaultKey,
+            user.SubscriptionTierId
+        );
+
+    private static UserProfileResponse ToProfile(Managers.UserResponse user) =>
+        new(
+            user.Id,
+            user.Email,
+            user.UserName,
+            user.PhoneNumber,
+            user.CreatedAt,
+            user.UpdatedAt,
+            user.LastLoginAt,
+            user.EncryptedVaultKey,
+            user.SubscriptionTierId
+        );
+}
+
+/// <summary>
+/// Summary DTO for vault information in user context.
+/// </summary>
+public record VaultSummaryDto(int Id, string Name, string? Description, DateTime CreatedAt);

--- a/PassManAPI/Models/User.cs
+++ b/PassManAPI/Models/User.cs
@@ -29,5 +29,6 @@ namespace PassManAPI.Models
         public virtual ICollection<Vault> Vaults { get; set; } = new List<Vault>();
         public virtual ICollection<VaultShare> SharedVaults { get; set; } = new List<VaultShare>();
         public virtual ICollection<AuditLog> AuditLogs { get; set; } = new List<AuditLog>();
+        public virtual ICollection<Tag> Tags { get; set; } = new List<Tag>();
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a new `UserController` with CRUD endpoints for user management, separating user administration from authentication concerns (AuthController).

## Changes

### New Files
- **PassManAPI/Controllers/UserController.cs** - New controller with the following endpoints:
  - `GET /api/user` - List all users (admin only, requires `UserManage` permission)
  - `GET /api/user/{id}` - Get user profile (self or admin)
  - `PUT /api/user/{id}` - Update user profile (self or admin)
  - `DELETE /api/user/{id}` - Delete user account (self or admin)
  - `GET /api/user/{id}/vaults` - Get user's vaults
  - `GET /api/user/{id}/tags` - Get user's tags

- **PassManAPI.Tests/UserEndpointsTests.cs** - Comprehensive test suite with 12 test cases covering:
  - Profile access scenarios (own profile, other users)
  - Update operations with permission checks
  - Delete operations with proper authorization
  - Vault and tag retrieval
  - Unauthenticated access handling

### Modified Files
- **PassManAPI/Models/User.cs** - Added `Tags` navigation property to complete the relationship with `Tag` model per the class diagram

## Testing
✅ All 60 tests passing (including 12 new User endpoint tests)

```
Test Run Successful.
Total tests: 60
     Passed: 60
```

## Related Issues
Closes #144 (partial - implements UserController, future work needed to consolidate UserManager/AuthManager overlap)

## Checklist
- [x] Tests added and passing
- [x] Code follows existing patterns
- [x] Authorization properly enforced
- [x] Documentation/XML comments added