### PR TITLE
Attachment model

### DIFF
--- a/PassManAPI.Tests/CredentialsEndpointsTests.cs
+++ b/PassManAPI.Tests/CredentialsEndpointsTests.cs
@@ -200,6 +200,118 @@ public class CredentialsEndpointsTests : IClassFixture<TestWebApplicationFactory
         items!.Should().NotContain(i => i.Id == created.Id);
     }
 
+    [Fact]
+    public async Task Owner_Can_Retrieve_Decrypted_Password()
+    {
+        var user = await RegisterAsync("cred-password-get@test.local");
+
+        // Create vault
+        var vault = new
+        {
+            name = "Owner Vault",
+            description = "owner vault",
+            userId = user.User.Id
+        };
+        var vaultRequest = new HttpRequestMessage(HttpMethod.Post, "/api/vaults")
+        {
+            Content = JsonContent.Create(vault)
+        };
+        vaultRequest.Headers.Add("X-UserId", user.User.Id.ToString());
+        var vaultResponse = await _client.SendAsync(vaultRequest);
+        vaultResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var vaultPayload = await vaultResponse.Content.ReadFromJsonAsync<CreatedVaultResponse>();
+
+        // Create credential with plaintext password
+        var originalPassword = "MySecretPassword123!";
+        var cred = new
+        {
+            Title = "Email",
+            Username = "alice",
+            EncryptedPassword = originalPassword,
+            Url = "https://mail.test",
+            Notes = "test note",
+            CategoryId = (int?)null
+        };
+        var credRequest = new HttpRequestMessage(HttpMethod.Post, $"/api/vaults/{vaultPayload!.Id}/credentials")
+        {
+            Content = JsonContent.Create(cred)
+        };
+        credRequest.Headers.Add("X-UserId", user.User.Id.ToString());
+        var credResponse = await _client.SendAsync(credRequest);
+        credResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await credResponse.Content.ReadFromJsonAsync<IdResponse>();
+
+        // Retrieve decrypted password
+        var getPasswordReq = new HttpRequestMessage(HttpMethod.Get, $"/api/credentials/{created!.Id}/password");
+        getPasswordReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        var getPasswordResp = await _client.SendAsync(getPasswordReq);
+        getPasswordResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var passwordPayload = await getPasswordResp.Content.ReadFromJsonAsync<PasswordResponse>();
+        passwordPayload.Should().NotBeNull();
+        passwordPayload!.Password.Should().Be(originalPassword);
+    }
+
+    [Fact]
+    public async Task Owner_Can_Update_Password()
+    {
+        var user = await RegisterAsync("cred-password-update@test.local");
+
+        // Create vault
+        var vault = new
+        {
+            name = "Owner Vault",
+            description = "owner vault",
+            userId = user.User.Id
+        };
+        var vaultRequest = new HttpRequestMessage(HttpMethod.Post, "/api/vaults")
+        {
+            Content = JsonContent.Create(vault)
+        };
+        vaultRequest.Headers.Add("X-UserId", user.User.Id.ToString());
+        var vaultResponse = await _client.SendAsync(vaultRequest);
+        vaultResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var vaultPayload = await vaultResponse.Content.ReadFromJsonAsync<CreatedVaultResponse>();
+
+        // Create credential
+        var originalPassword = "OldPassword123!";
+        var cred = new
+        {
+            Title = "Email",
+            Username = "alice",
+            EncryptedPassword = originalPassword,
+            Url = "https://mail.test",
+            Notes = "test note",
+            CategoryId = (int?)null
+        };
+        var credRequest = new HttpRequestMessage(HttpMethod.Post, $"/api/vaults/{vaultPayload!.Id}/credentials")
+        {
+            Content = JsonContent.Create(cred)
+        };
+        credRequest.Headers.Add("X-UserId", user.User.Id.ToString());
+        var credResponse = await _client.SendAsync(credRequest);
+        credResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await credResponse.Content.ReadFromJsonAsync<IdResponse>();
+
+        // Update password
+        var newPassword = "NewPassword456!";
+        var updatePasswordReq = new HttpRequestMessage(HttpMethod.Put, $"/api/credentials/{created!.Id}/password")
+        {
+            Content = JsonContent.Create(new { EncryptedPassword = newPassword })
+        };
+        updatePasswordReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        var updatePasswordResp = await _client.SendAsync(updatePasswordReq);
+        updatePasswordResp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Verify new password
+        var getPasswordReq = new HttpRequestMessage(HttpMethod.Get, $"/api/credentials/{created.Id}/password");
+        getPasswordReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        var getPasswordResp = await _client.SendAsync(getPasswordReq);
+        getPasswordResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var passwordPayload = await getPasswordResp.Content.ReadFromJsonAsync<PasswordResponse>();
+        passwordPayload.Should().NotBeNull();
+        passwordPayload!.Password.Should().Be(newPassword);
+    }
+
     private async Task<AuthResponse> LoginAsync(string email, string password)
     {
         var response = await _client.PostAsJsonAsync("/api/auth/login", new LoginRequest
@@ -242,5 +354,7 @@ public class CredentialsEndpointsTests : IClassFixture<TestWebApplicationFactory
     );
 
     private record IdResponse(int Id);
+
+    private record PasswordResponse(string Password);
 }
 

--- a/PassManAPI.Tests/TestWebApplicationFactory.cs
+++ b/PassManAPI.Tests/TestWebApplicationFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using PassManAPI.Data;
 using PassManAPI.Models;
+using Microsoft.AspNetCore.DataProtection;
 
 namespace PassManAPI.Tests;
 
@@ -36,6 +37,9 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
                 options.UseSqlite(connection);
                 options.EnableSensitiveDataLogging();
             });
+
+            // Use Ephemeral keys for DataProtection to suppress file system warnings
+            services.AddDataProtection().UseEphemeralDataProtectionProvider();
 
             // Build service provider to apply schema
             var sp = services.BuildServiceProvider();

--- a/PassManAPI/Controllers/CredentialsController.cs
+++ b/PassManAPI/Controllers/CredentialsController.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using PassManAPI.Data;
 using PassManAPI.DTOs;
 using PassManAPI.Models;
+using PassManAPI.Services;
 using System.Security.Claims;
 using System.ComponentModel.DataAnnotations;
 
@@ -14,10 +15,12 @@ namespace PassManAPI.Controllers;
 public class CredentialsController : ControllerBase
 {
     private readonly ApplicationDbContext _db;
+    private readonly IPasswordEncryptionService _encryptionService;
 
-    public CredentialsController(ApplicationDbContext db)
+    public CredentialsController(ApplicationDbContext db, IPasswordEncryptionService encryptionService)
     {
         _db = db;
+        _encryptionService = encryptionService;
     }
 
     /// <summary>
@@ -106,11 +109,23 @@ public class CredentialsController : ControllerBase
             return Forbid();
         }
 
+        // Generate a per-credential encryption key (32 bytes)
+        var perCredentialKey = _encryptionService.GeneratePerCredentialKey();
+        
+        // Encrypt the password using the per-credential key  
+        // Note: request.EncryptedPassword contains the plaintext password from the client
+        var encryptedPasswordBytes = _encryptionService.EncryptPassword(request.EncryptedPassword, perCredentialKey);
+        var encryptedPasswordBase64 = Convert.ToBase64String(encryptedPasswordBytes);
+        
+        // Store the per-credential key as Base64 (in production, this should be encrypted with user's master password)
+        // For now, we'll store it alongside the credential (this is a simplified implementation)
+        var perCredentialKeyBase64 = Convert.ToBase64String(perCredentialKey);
+
         var credential = new Credential
         {
             Title = request.Title.Trim(),
             Username = string.IsNullOrWhiteSpace(request.Username) ? null : request.Username.Trim(),
-            EncryptedPassword = request.EncryptedPassword,
+            EncryptedPassword = $"{perCredentialKeyBase64}:{encryptedPasswordBase64}",
             Url = string.IsNullOrWhiteSpace(request.Url) ? null : request.Url.Trim(),
             Notes = request.Notes,
             CategoryId = request.CategoryId,
@@ -122,6 +137,70 @@ public class CredentialsController : ControllerBase
         await _db.SaveChangesAsync();
 
         return Created($"/api/vaults/{vaultId}/credentials/{credential.Id}", new { credential.Id });
+    }
+
+    /// <summary>
+    /// Retrieves the decrypted password for a specific credential.
+    /// </summary>
+    /// <remarks>
+    /// This endpoint returns the plaintext password after decryption.
+    /// Use with caution and ensure secure transmission.
+    /// </remarks>
+    /// <param name="id">The unique identifier of the credential.</param>
+    /// <response code="200">Returns the decrypted password.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    /// <response code="403">If the user does not have permission to access the credential.</response>
+    /// <response code="404">If the credential with the specified ID is not found.</response>
+    [HttpGet("/api/credentials/{id:int}/password")]
+    [Authorize(Policy = PermissionConstants.CredentialRead)]
+    public async Task<IActionResult> GetPassword(int id)
+    {
+        if (!TryGetCurrentUserId(out var currentUserId))
+        {
+            return Unauthorized();
+        }
+
+        var credential = await _db.Credentials
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id);
+
+        if (credential is null)
+        {
+            return NotFound();
+        }
+
+        var canAccess = await CanAccessVault(credential.VaultId, currentUserId);
+        if (!canAccess)
+        {
+            return Forbid();
+        }
+
+        // Update last accessed timestamp
+        var credentialToUpdate = await _db.Credentials.FindAsync(id);
+        if (credentialToUpdate != null)
+        {
+            credentialToUpdate.LastAccessed = DateTime.UtcNow;
+            await _db.SaveChangesAsync();
+        }
+
+        // Parse the encrypted password (format: "key:encryptedPassword")
+        var parts = credential.EncryptedPassword.Split(':', 2);
+        if (parts.Length != 2)
+        {
+            // Handle legacy format (unencrypted)
+            return Ok(new { password = credential.EncryptedPassword });
+        }
+
+        var perCredentialKeyBase64 = parts[0];
+        var encryptedPasswordBase64 = parts[1];
+
+        var perCredentialKey = Convert.FromBase64String(perCredentialKeyBase64);
+        var encryptedPasswordBytes = Convert.FromBase64String(encryptedPasswordBase64);
+
+        // Decrypt the password
+        var decryptedPassword = _encryptionService.DecryptPassword(encryptedPasswordBytes, perCredentialKey);
+
+        return Ok(new { password = decryptedPassword });
     }
 
     /// <summary>
@@ -170,6 +249,61 @@ public class CredentialsController : ControllerBase
         credential.Url = string.IsNullOrWhiteSpace(update.Url) ? null : update.Url.Trim();
         credential.Notes = update.Notes;
         credential.CategoryId = update.CategoryId;
+        credential.UpdatedAt = DateTime.UtcNow;
+
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Updates the password of an existing credential.
+    /// </summary>
+    /// <remarks>
+    /// This endpoint updates only the password field of a credential.
+    /// The new password will be encrypted before storage.
+    /// </remarks>
+    /// <param name="id">The unique identifier of the credential to update.</param>
+    /// <param name="request">The new password (plaintext).</param>
+    /// <response code="204">If the password was updated successfully.</response>
+    /// <response code="400">If the provided password data is invalid.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    /// <response code="403">If the user does not have permission to modify the credential.</response>
+    /// <response code="404">If the credential with the specified ID is not found.</response>
+    [HttpPut("/api/credentials/{id:int}/password")]
+    [Authorize(Policy = PermissionConstants.CredentialUpdate)]
+    public async Task<IActionResult> UpdatePassword(int id, [FromBody] UpdateCredentialPasswordRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        if (!TryGetCurrentUserId(out var currentUserId))
+        {
+            return Unauthorized();
+        }
+
+        var credential = await _db.Credentials.FirstOrDefaultAsync(c => c.Id == id);
+        if (credential is null)
+        {
+            return NotFound();
+        }
+
+        var canAccess = await CanAccessVault(credential.VaultId, currentUserId);
+        if (!canAccess)
+        {
+            return Forbid();
+        }
+
+        // Generate a new per-credential encryption key
+        var perCredentialKey = _encryptionService.GeneratePerCredentialKey();
+        
+        // Encrypt the new password
+        var encryptedPasswordBytes = _encryptionService.EncryptPassword(request.EncryptedPassword, perCredentialKey);
+        var encryptedPasswordBase64 = Convert.ToBase64String(encryptedPasswordBytes);
+        var perCredentialKeyBase64 = Convert.ToBase64String(perCredentialKey);
+
+        credential.EncryptedPassword = $"{perCredentialKeyBase64}:{encryptedPasswordBase64}";
         credential.UpdatedAt = DateTime.UtcNow;
 
         await _db.SaveChangesAsync();

--- a/PassManAPI/Controllers/CredentialsController.cs
+++ b/PassManAPI/Controllers/CredentialsController.cs
@@ -81,7 +81,7 @@ public class CredentialsController : ControllerBase
     /// The provided credential data will be encrypted before being stored.
     /// </remarks>
     /// <param name="vaultId">The unique identifier of the vault where the credential will be stored.</param>
-    /// <param name="credential">The credential object to be created. The password within this object will be encrypted.</param>
+    /// <param name="request">The credential object to be created. The password within this object will be encrypted.</param>
     /// <response code="201">Returns the newly created credential's location.</response>
     /// <response code="400">If the provided credential data is invalid.</response>
     /// <response code="401">If the user is not authenticated.</response>
@@ -211,7 +211,7 @@ public class CredentialsController : ControllerBase
     /// Any sensitive information will be re-encrypted upon update.
     /// </remarks>
     /// <param name="id">The unique identifier of the credential to update.</param>
-    /// <param name="credential">The updated credential object.</param>
+    /// <param name="update">The updated credential object.</param>
     /// <response code="204">If the credential was updated successfully.</response>
     /// <response code="400">If the provided credential data is invalid.</response>
     /// <response code="401">If the user is not authenticated.</response>

--- a/PassManAPI/Program.cs
+++ b/PassManAPI/Program.cs
@@ -283,7 +283,10 @@ public class Program
             app.UseSwaggerUI();
         }
 
-        app.UseHttpsRedirection();
+        if (!app.Environment.IsEnvironment("Test"))
+        {
+            app.UseHttpsRedirection();
+        }
 
         // Enable CORS
         app.UseCors("AllowFrontend");


### PR DESCRIPTION
This pull request introduces password encryption and decryption functionality for credentials, along with corresponding API endpoints and tests. It ensures that passwords are securely stored using per-credential encryption keys, and allows users to retrieve and update their decrypted passwords via dedicated endpoints. The changes also improve the test infrastructure and update documentation for clarity.

**Credential password encryption and API enhancements:**

* The `CredentialsController` now uses an `IPasswordEncryptionService` to generate a per-credential encryption key and encrypt passwords before storing them. The encrypted password and key are stored together in the `EncryptedPassword` field in a new format (`key:encryptedPassword`). [[1]](diffhunk://#diff-a972ed9ef52a9fa69cfa22e800787c10b384d59d6f0543b30a5d061ccdffe473R18-R23) [[2]](diffhunk://#diff-a972ed9ef52a9fa69cfa22e800787c10b384d59d6f0543b30a5d061ccdffe473R112-R128)
* Added a new endpoint `GET /api/credentials/{id}/password` to retrieve the decrypted password for a credential, handling both new and legacy formats.
* Added a new endpoint `PUT /api/credentials/{id}/password` to update the password of a credential. This generates a new encryption key and re-encrypts the password.
* Updated XML documentation and parameter names for clarity in the controller methods. [[1]](diffhunk://#diff-a972ed9ef52a9fa69cfa22e800787c10b384d59d6f0543b30a5d061ccdffe473L81-R84) [[2]](diffhunk://#diff-a972ed9ef52a9fa69cfa22e800787c10b384d59d6f0543b30a5d061ccdffe473L135-R214)

**Testing improvements:**

* Added tests to verify that credential owners can retrieve and update decrypted passwords, ensuring end-to-end encryption and decryption flows work as intended.
* Added a `PasswordResponse` record to handle password responses in tests.
* The test web application now uses ephemeral data protection keys to suppress file system warnings and avoid persisting keys during tests. [[1]](diffhunk://#diff-f9c78d94773f0ad3161a18b6b9c00eef57a2366d975f9c727164f29459af01fdR11) [[2]](diffhunk://#diff-f9c78d94773f0ad3161a18b6b9c00eef57a2366d975f9c727164f29459af01fdR41-R43)

**Environment and configuration:**

* HTTPS redirection is now disabled in the test environment to simplify local and CI testing.