### PR TITLE
refactor: remove unused AddCredential/RemoveCredential from CredentialTag (#169)

### DIFF
--- a/PassManAPI/Models/CredentialTag.cs
+++ b/PassManAPI/Models/CredentialTag.cs
@@ -28,22 +28,5 @@ namespace PassManAPI.Models
             CredentialId = credentialId;
             TagId = tagId;
         }
-
-        // Add credential to this tag relationship (from UML specification)
-        public void AddCredential(Credential credential)
-        {
-            Credential = credential;
-            CredentialId = credential.Id;
-        }
-
-        // Remove credential from this tag relationship (from UML specification)
-        public void RemoveCredential(Credential credential)
-        {
-            if (CredentialId == credential.Id)
-            {
-                Credential = null!;
-                CredentialId = 0;
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary
`CredentialTag.AddCredential` and `CredentialTag.RemoveCredential` were leftover UML-spec stubs with **zero references** anywhere in the solution. The join entity is only ever constructed via its `CredentialTag(int credentialId, int tagId)` constructor (e.g. in `CredentialsController.SetCredentialTags` / `AddTagToCredential`), never via these methods.

## Change
- Deleted both methods from `PassManAPI/Models/CredentialTag.cs`. The entity, composite keys, navigation properties, and both constructors are untouched.

## Verification
- `docker compose --profile test run --rm test` → build clean, **105/105 tests pass**.

Closes #169