### PR TITLE
fix: most endpoints return 403 under JWT auth — embed role/permission claims (#159)

### DIFF
--- a/PassManAPI.Tests/JwtAuthFlowTests.cs
+++ b/PassManAPI.Tests/JwtAuthFlowTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using PassManAPI.DTOs;
+using Xunit;
+
+namespace PassManAPI.Tests;
+
+/// <summary>
+/// Exercises the real JWT bearer-token path (as opposed to the X-UserId dev header used by
+/// the other endpoint tests). Regression coverage for #159: the JWT issued on register/login
+/// must embed the user's role + permission claims, otherwise every permission-protected
+/// endpoint returns 403 even though the user has the permissions in the database.
+/// </summary>
+public class JwtAuthFlowTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public JwtAuthFlowTests(TestWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task BearerToken_From_Register_Can_Access_Permission_Protected_Endpoint()
+    {
+        var auth = await RegisterAsync("jwt-flow@test.local");
+        auth.AccessToken.Should().NotBeNullOrWhiteSpace();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/vaults");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", auth.AccessToken);
+
+        var response = await _client.SendAsync(request);
+
+        // Before the fix this returned 403 (token carried no "permission" claims).
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task BearerToken_From_Login_Can_Access_Permission_Protected_Endpoint()
+    {
+        const string email = "jwt-login-flow@test.local";
+        await RegisterAsync(email);
+
+        var loginResponse = await _client.PostAsJsonAsync(
+            "/api/auth/login",
+            new LoginRequest { Email = email, Password = "Password1!" });
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var auth = await loginResponse.Content.ReadFromJsonAsync<AuthResponse>();
+        auth!.AccessToken.Should().NotBeNullOrWhiteSpace();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/tags");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", auth.AccessToken);
+
+        var response = await _client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Permission_Protected_Endpoint_Without_Token_Returns_401()
+    {
+        var response = await _client.GetAsync("/api/vaults");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task<AuthResponse> RegisterAsync(string email)
+    {
+        var request = new RegisterRequest
+        {
+            Email = email,
+            Password = "Password1!",
+            ConfirmPassword = "Password1!",
+            UserName = email.Split('@')[0],
+            PhoneNumber = "1234567890"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/auth/register", request);
+        response.EnsureSuccessStatusCode();
+        var payload = await response.Content.ReadFromJsonAsync<AuthResponse>();
+        return payload!;
+    }
+}

--- a/PassManAPI/Controllers/AuthController.cs
+++ b/PassManAPI/Controllers/AuthController.cs
@@ -89,11 +89,7 @@ public class AuthController : ControllerBase
             return BadRequest(string.Join(", ", roleResult.Errors.Select(e => e.Description)));
         }
 
-        var token = _jwtTokenService.CreateAccessToken(
-            result.Data.Id,
-            result.Data.Email,
-            result.Data.UserName
-        );
+        var token = await _jwtTokenService.CreateAccessTokenAsync(identityUser);
         var response = new AuthResponse
         {
             AccessToken = token,
@@ -147,7 +143,7 @@ public class AuthController : ControllerBase
         user.LastLoginAt = DateTime.UtcNow;
         await _identityUserManager.UpdateAsync(user);
 
-        var token = _jwtTokenService.CreateAccessToken(user);
+        var token = await _jwtTokenService.CreateAccessTokenAsync(user);
         return Ok(new AuthResponse
         {
             AccessToken = token,
@@ -207,7 +203,7 @@ public class AuthController : ControllerBase
                 await _db.SaveChangesAsync();
             }
 
-            var token = _jwtTokenService.CreateAccessToken(user);
+            var token = await _jwtTokenService.CreateAccessTokenAsync(user);
             return Ok(new AuthResponse
             {
                 AccessToken = token,

--- a/PassManAPI/Services/JwtTokenService.cs
+++ b/PassManAPI/Services/JwtTokenService.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using PassManAPI.Models;
@@ -9,27 +10,28 @@ namespace PassManAPI.Services;
 
 public interface IJwtTokenService
 {
-    // Issues a short-lived access token for the given user.
-    string CreateAccessToken(User user);
-    // Overload used when we only have a response DTO, not the full entity.
-    string CreateAccessToken(int userId, string email, string? userName);
+    // Issues a short-lived access token for the given user, including the user's
+    // role and permission claims so authorization policies can be satisfied.
+    Task<string> CreateAccessTokenAsync(User user);
 }
 
 public class JwtTokenService : IJwtTokenService
 {
     private readonly JwtOptions _options;
+    private readonly UserManager<User> _userManager;
+    private readonly RoleManager<IdentityRole<int>> _roleManager;
 
-    public JwtTokenService(IOptions<JwtOptions> options)
+    public JwtTokenService(
+        IOptions<JwtOptions> options,
+        UserManager<User> userManager,
+        RoleManager<IdentityRole<int>> roleManager)
     {
         _options = options.Value;
+        _userManager = userManager;
+        _roleManager = roleManager;
     }
 
-    public string CreateAccessToken(User user)
-    {
-        return CreateAccessToken(user.Id, user.Email ?? string.Empty, user.UserName);
-    }
-
-    public string CreateAccessToken(int userId, string email, string? userName)
+    public async Task<string> CreateAccessTokenAsync(User user)
     {
         if (string.IsNullOrWhiteSpace(_options.SigningKey))
         {
@@ -40,15 +42,36 @@ public class JwtTokenService : IJwtTokenService
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_options.SigningKey));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
-        // Minimal claims: user id, email, name, and token id.
+        // Base claims: user id, email, name, and token id.
         var claims = new List<Claim>
         {
-            new(JwtRegisteredClaimNames.Sub, userId.ToString()),
-            new(ClaimTypes.NameIdentifier, userId.ToString()),
-            new(JwtRegisteredClaimNames.Email, email ?? string.Empty),
-            new(ClaimTypes.Name, userName ?? email ?? string.Empty),
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(ClaimTypes.NameIdentifier, user.Id.ToString()),
+            new(JwtRegisteredClaimNames.Email, user.Email ?? string.Empty),
+            new(ClaimTypes.Name, user.UserName ?? user.Email ?? string.Empty),
             new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
         };
+
+        // Embed the user's roles and their associated permission claims so that the
+        // authorization policies (which RequireClaim "permission") are satisfied.
+        // Without this, every permission-protected endpoint returns 403 under JWT auth.
+        // Mirrors DevHeaderAuthenticationHandler so JWT and dev-header auth behave identically.
+        var roles = await _userManager.GetRolesAsync(user);
+        foreach (var roleName in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, roleName));
+
+            var role = await _roleManager.FindByNameAsync(roleName);
+            if (role is null)
+            {
+                continue;
+            }
+
+            var roleClaims = await _roleManager.GetClaimsAsync(role);
+            claims.AddRange(
+                roleClaims.Where(c => c.Type == PermissionConstants.ClaimType)
+            );
+        }
 
         var token = new JwtSecurityToken(
             issuer: _options.Issuer,


### PR DESCRIPTION
## Problem
On a fresh environment, **most endpoints fail** even with a valid login. Reproduced against a clean Docker stack:

| Request (with a valid JWT from `/register` or `/login`) | Before |
|---|---|
| `GET /api/auth/me` (only `[Authorize]`) | 200 ✅ |
| `GET /api/auth/permissions` | returns all 13 perms ✅ |
| `GET /api/vaults` (needs `vault.read`) | **403 ❌** |
| `GET /api/tags` (needs `tag.read`) | **403 ❌** |
| `POST /api/vaults` (needs `vault.create`) | **403 ❌** |

## Root cause
`JwtTokenService.CreateAccessToken` issued tokens containing only `sub / nameidentifier / email / name / jti` — **no role or `permission` claims**. Every endpoint guarded by `[Authorize(Policy = …)]` uses `RequireClaim("permission", …)`, so the token could never satisfy the policy → **403 on every permission-protected endpoint**.

The user *does* have the permissions in the DB (proven by `/api/auth/permissions`). They simply weren't being put into the token.

Why tests didn't catch it: the integration tests authenticate via the `X-UserId` dev header (`DevHeaderAuthenticationHandler`), which **does** load roles and inject `permission` claims. So tests were green while the real bearer-token flow used by clients/graders was broken.

## Fix
`JwtTokenService` now loads the user's roles and their associated permission claims and embeds them in the JWT — mirroring `DevHeaderAuthenticationHandler` so JWT auth and dev-header auth behave identically. The token-creation method became async (`CreateAccessTokenAsync`); the three `AuthController` call sites (register/login/google) were updated.

## Verification
- Reproduced **403 → 200** live against the Docker stack after the fix; `GET /api/vaults` and `GET /api/tags` now return 200, `POST` returns 201, and requests **without** a token still return 401.
- Decoded JWT now contains `role` + 13 `permission` claims.
- Added `JwtAuthFlowTests` exercising the real **bearer-token** path (register/login → permission-protected endpoint → 200; no token → 401).
- `docker compose --profile test run --rm test` → **108/108 pass** (105 existing + 3 new).

Closes #159