### PR TITLE
fix: error responses support both XML and JSON (#178)

### DIFF
--- a/PassManAPI.Tests/XmlSerializationTests.cs
+++ b/PassManAPI.Tests/XmlSerializationTests.cs
@@ -203,6 +203,57 @@ public class XmlSerializationTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task Controller_Error_Should_Serialize_As_XML_When_Accept_Is_XML()
+    {
+        // A controller-returned error (404 "Vault not found." from CredentialsController) must
+        // content-negotiate to XML — previously the helper forced application/problem+json.
+        var user = await RegisterAsync($"xml-err-{Guid.NewGuid()}@test.local");
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/vaults/999999/credentials");
+        request.Headers.Add("X-UserId", user.User.Id.ToString());
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+
+        var xml = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        xml.Root!.Name.LocalName.Should().Be("ErrorResponse");
+        xml.Root.Element("Detail")!.Value.Should().Contain("Vault not found");
+    }
+
+    [Fact]
+    public async Task Middleware_Unauthorized_Should_Serialize_As_XML_When_Accept_Is_XML()
+    {
+        // A 401 produced by the auth pipeline (no controller body) must also be available as XML.
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/auth/me");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+
+        var xml = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        xml.Root!.Name.LocalName.Should().Be("ErrorResponse");
+        xml.Root.Element("Status")!.Value.Should().Be("401");
+    }
+
+    [Fact]
+    public async Task Error_Should_Default_To_Json_When_Xml_Not_Requested()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/auth/me");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Content.Headers.ContentType?.MediaType.Should().Contain("json");
+        (await response.Content.ReadAsStringAsync()).Should().Contain("\"status\":401");
+    }
+
+    [Fact]
     public async Task JSON_Should_Still_Work_When_XML_Is_Enabled()
     {
         // Arrange

--- a/PassManAPI/Controllers/AuthController.cs
+++ b/PassManAPI/Controllers/AuthController.cs
@@ -428,7 +428,7 @@ public class AuthController : ControllerBase
             return this.BadRequestProblem(string.Join(", ", result.Errors.Select(e => e.Description)));
         }
 
-        return Ok(new { Message = $"User assigned to role '{request.RoleName}' successfully." });
+        return Ok(new MessageResponse { Message = $"User assigned to role '{request.RoleName}' successfully." });
     }
 
     /// <summary>

--- a/PassManAPI/Controllers/CredentialsController.cs
+++ b/PassManAPI/Controllers/CredentialsController.cs
@@ -412,6 +412,8 @@ public class CredentialsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> SetCredentialTags(int id, [FromBody] AssignTagsRequest request)
     {
+        request.TagIds ??= new();
+
         if (!ModelState.IsValid)
         {
             return ValidationProblem(ModelState);
@@ -437,14 +439,16 @@ public class CredentialsController : ControllerBase
             return this.ForbiddenProblem();
         }
 
-        // Validate all tag ids belong to the current user
-        var validTagIds = await _db.Tags
+        // Validate all tag ids belong to the current user.
+        // Pomelo MySQL EF Core 9 preview does not support primitive-collection Contains in LINQ-to-SQL,
+        // so fetch all of the user's tag IDs first and validate in memory.
+        var userTagIds = await _db.Tags
             .AsNoTracking()
-            .Where(t => t.UserId == currentUserId && request.TagIds.Contains(t.Id))
+            .Where(t => t.UserId == currentUserId)
             .Select(t => t.Id)
             .ToListAsync();
 
-        var invalidTagIds = request.TagIds.Except(validTagIds).ToList();
+        var invalidTagIds = request.TagIds.Except(userTagIds).ToList();
         if (invalidTagIds.Any())
         {
             return this.BadRequestProblem($"Invalid or unauthorized tag ids: {string.Join(", ", invalidTagIds)}");

--- a/PassManAPI/Controllers/CredentialsController.cs
+++ b/PassManAPI/Controllers/CredentialsController.cs
@@ -57,15 +57,15 @@ public class CredentialsController : ControllerBase
             .Where(c => c.VaultId == vaultId)
             .Include(c => c.CredentialTags)
                 .ThenInclude(ct => ct.Tag)
-            .Select(c => new
+            .Select(c => new CredentialListItemDto
             {
-                c.Id,
-                c.Title,
-                c.Username,
-                c.Url,
-                c.CreatedAt,
-                c.UpdatedAt,
-                c.LastAccessed,
+                Id = c.Id,
+                Title = c.Title,
+                Username = c.Username,
+                Url = c.Url,
+                CreatedAt = c.CreatedAt,
+                UpdatedAt = c.UpdatedAt,
+                LastAccessed = c.LastAccessed,
                 Tags = c.CredentialTags.Select(ct => new TagDto(ct.Tag.Id, ct.Tag.Name)).ToList()
             })
             .ToListAsync();
@@ -136,7 +136,7 @@ public class CredentialsController : ControllerBase
         _db.Credentials.Add(credential);
         await _db.SaveChangesAsync();
 
-        return Created($"/api/vaults/{vaultId}/credentials/{credential.Id}", new { credential.Id });
+        return Created($"/api/vaults/{vaultId}/credentials/{credential.Id}", new IdResponse { Id = credential.Id });
     }
 
     /// <summary>
@@ -188,7 +188,7 @@ public class CredentialsController : ControllerBase
         if (parts.Length != 2)
         {
             // Handle legacy format (unencrypted)
-            return Ok(new { password = credential.EncryptedPassword });
+            return Ok(new PasswordResponse { Password = credential.EncryptedPassword });
         }
 
         var perCredentialKeyBase64 = parts[0];
@@ -200,7 +200,7 @@ public class CredentialsController : ControllerBase
         // Decrypt the password
         var decryptedPassword = _encryptionService.DecryptPassword(encryptedPasswordBytes, perCredentialKey);
 
-        return Ok(new { password = decryptedPassword });
+        return Ok(new PasswordResponse { Password = decryptedPassword });
     }
 
     /// <summary>
@@ -529,7 +529,7 @@ public class CredentialsController : ControllerBase
         _db.CredentialTags.Add(new CredentialTag(id, tagId));
         await _db.SaveChangesAsync();
 
-        return Ok(new { message = "Tag added successfully." });
+        return Ok(new MessageResponse { Message = "Tag added successfully." });
     }
 
     /// <summary>

--- a/PassManAPI/Controllers/InvitationsController.cs
+++ b/PassManAPI/Controllers/InvitationsController.cs
@@ -188,7 +188,7 @@ namespace PassManAPI.Controllers
 
             await _context.SaveChangesAsync();
 
-            return Ok(new { Message = "Invitation accepted.", VaultId = invitation.VaultId });
+            return Ok(new AcceptInvitationResponse { Message = "Invitation accepted.", VaultId = invitation.VaultId });
         }
 
         // DELETE: api/invitations/{id}

--- a/PassManAPI/Controllers/UserController.cs
+++ b/PassManAPI/Controllers/UserController.cs
@@ -271,4 +271,16 @@ public class UserController : ControllerBase
 /// <summary>
 /// Summary DTO for vault information in user context.
 /// </summary>
-public record VaultSummaryDto(int Id, string Name, string? Description, DateTime CreatedAt);
+public class VaultSummaryDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    public VaultSummaryDto() { }
+    public VaultSummaryDto(int id, string name, string? description, DateTime createdAt)
+    {
+        Id = id; Name = name; Description = description; CreatedAt = createdAt;
+    }
+}

--- a/PassManAPI/DTOs/AuditDtos.cs
+++ b/PassManAPI/DTOs/AuditDtos.cs
@@ -69,7 +69,8 @@ public class PaginatedAuditResult
     public int TotalCount { get; set; }
     public int Page { get; set; }
     public int PageSize { get; set; }
-    public int TotalPages => (int)Math.Ceiling((double)TotalCount / PageSize);
-    public bool HasNextPage => Page < TotalPages;
-    public bool HasPreviousPage => Page > 1;
+    // Computed fields; setters are stubs required by XmlSerializer (getter-only properties are skipped).
+    public int TotalPages { get => (int)Math.Ceiling((double)TotalCount / PageSize); set { } }
+    public bool HasNextPage { get => Page < TotalPages; set { } }
+    public bool HasPreviousPage { get => Page > 1; set { } }
 }

--- a/PassManAPI/DTOs/CommonResponses.cs
+++ b/PassManAPI/DTOs/CommonResponses.cs
@@ -33,3 +33,28 @@ public record RoleAssignmentResponse
     public int UserId { get; init; }
     public string Role { get; init; } = string.Empty;
 }
+
+/// <summary>
+/// Generic single-message response.
+/// </summary>
+public class MessageResponse
+{
+    public string Message { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Response returned when an invitation is accepted.
+/// </summary>
+public class AcceptInvitationResponse
+{
+    public string Message { get; set; } = string.Empty;
+    public int VaultId { get; set; }
+}
+
+/// <summary>
+/// Response containing a decrypted credential password.
+/// </summary>
+public class PasswordResponse
+{
+    public string Password { get; set; } = string.Empty;
+}

--- a/PassManAPI/DTOs/CredentialDto.cs
+++ b/PassManAPI/DTOs/CredentialDto.cs
@@ -3,6 +3,21 @@ using System.ComponentModel.DataAnnotations;
 namespace PassManAPI.DTOs;
 
 /// <summary>
+/// Lightweight credential response used in list endpoints (no notes/category/vaultId).
+/// </summary>
+public class CredentialListItemDto
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string? Username { get; set; }
+    public string? Url { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public DateTime? LastAccessed { get; set; }
+    public List<TagDto> Tags { get; set; } = new();
+}
+
+/// <summary>
 /// Response DTO for Credential information.
 /// Note: Does not include the encrypted password for security reasons.
 /// </summary>

--- a/PassManAPI/DTOs/ErrorResponse.cs
+++ b/PassManAPI/DTOs/ErrorResponse.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using System.Xml.Serialization;
 
 namespace PassManAPI.DTOs;
 
@@ -43,8 +44,22 @@ public class ErrorResponse
     /// </summary>
     [JsonPropertyName("errors")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [System.Xml.Serialization.XmlIgnore] // Dictionary is not XML-serializable; errors are JSON-only.
+    [XmlIgnore] // A Dictionary isn't XML-serializable; XML uses the list view below.
     public Dictionary<string, string[]>? Errors { get; set; }
+
+    /// <summary>
+    /// XML-serializable view of <see cref="Errors"/>. JSON emits the <c>errors</c> object above;
+    /// XML can't serialize a dictionary, so the same field errors are exposed here as a list so that
+    /// error bodies carry validation details in <b>both</b> formats.
+    /// </summary>
+    [JsonIgnore]
+    [XmlArray("errors")]
+    [XmlArrayItem("error")]
+    public List<ValidationError>? ValidationErrors
+    {
+        get => Errors?.Select(kv => new ValidationError { Field = kv.Key, Messages = kv.Value }).ToList();
+        set => Errors = value?.ToDictionary(v => v.Field, v => v.Messages);
+    }
 
     /// <summary>
     /// Creates a Bad Request (400) error response.
@@ -165,4 +180,17 @@ public class ErrorResponse
             TraceId = traceId
         };
     }
+}
+
+/// <summary>
+/// XML-serializable representation of a single field's validation errors
+/// (the dictionary form used for JSON isn't XML-serializable).
+/// </summary>
+public class ValidationError
+{
+    [XmlAttribute("field")]
+    public string Field { get; set; } = string.Empty;
+
+    [XmlElement("message")]
+    public string[] Messages { get; set; } = Array.Empty<string>();
 }

--- a/PassManAPI/DTOs/TagDtos.cs
+++ b/PassManAPI/DTOs/TagDtos.cs
@@ -5,10 +5,14 @@ namespace PassManAPI.DTOs;
 /// <summary>
 /// Response DTO for Tag information.
 /// </summary>
-public record TagDto(
-    int Id,
-    string Name
-);
+public class TagDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+
+    public TagDto() { }
+    public TagDto(int id, string name) { Id = id; Name = name; }
+}
 
 /// <summary>
 /// Request DTO for creating a new tag.

--- a/PassManAPI/DTOs/TagDtos.cs
+++ b/PassManAPI/DTOs/TagDtos.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
 namespace PassManAPI.DTOs;
 
@@ -39,6 +40,6 @@ public class UpdateTagRequest
 /// </summary>
 public class AssignTagsRequest
 {
-    [Required]
+    [ValidateNever]
     public List<int> TagIds { get; set; } = new();
 }

--- a/PassManAPI/Helpers/ControllerErrorExtensions.cs
+++ b/PassManAPI/Helpers/ControllerErrorExtensions.cs
@@ -14,12 +14,14 @@ public static class ControllerErrorExtensions
     private static string TraceId(ControllerBase controller) =>
         Activity.Current?.Id ?? controller.HttpContext.TraceIdentifier;
 
-    /// <summary>Returns the given <see cref="ErrorResponse"/> with its status code and problem+json content type.</summary>
+    /// <summary>
+    /// Returns the given <see cref="ErrorResponse"/> with its status code. No explicit content type is
+    /// set, so MVC content-negotiates the body as JSON or XML based on the request's Accept header.
+    /// </summary>
     public static ObjectResult Error(this ControllerBase controller, ErrorResponse error) =>
         new(error)
         {
-            StatusCode = error.Status,
-            ContentTypes = { "application/problem+json" }
+            StatusCode = error.Status
         };
 
     public static ObjectResult BadRequestProblem(this ControllerBase controller, string detail) =>

--- a/PassManAPI/Middleware/AuthErrorBodyMiddleware.cs
+++ b/PassManAPI/Middleware/AuthErrorBodyMiddleware.cs
@@ -1,6 +1,4 @@
 using System.Diagnostics;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using PassManAPI.DTOs;
 
 namespace PassManAPI.Middleware;
@@ -11,15 +9,10 @@ namespace PassManAPI.Middleware;
 /// Controller-returned 401/403 already carry a body, so those are left untouched. This runs as an
 /// outer wrapper so it can inspect the final status code before the response is flushed — which is
 /// why it works across the JWT + dev-header multi-scheme setup where JwtBearer events did not.
+/// The body is content-negotiated (XML or JSON) via <see cref="ErrorResponseWriter"/>.
 /// </summary>
 public class AuthErrorBodyMiddleware
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-    };
-
     private readonly RequestDelegate _next;
 
     public AuthErrorBodyMiddleware(RequestDelegate next)
@@ -50,7 +43,7 @@ public class AuthErrorBodyMiddleware
 
         if (error is not null)
         {
-            await context.Response.WriteAsJsonAsync(error, JsonOptions, "application/problem+json");
+            await ErrorResponseWriter.WriteAsync(context, error);
         }
     }
 }

--- a/PassManAPI/Middleware/ErrorResponseWriter.cs
+++ b/PassManAPI/Middleware/ErrorResponseWriter.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using PassManAPI.DTOs;
+
+namespace PassManAPI.Middleware;
+
+/// <summary>
+/// Writes an <see cref="ErrorResponse"/> to the response, content-negotiated between XML and JSON
+/// from the request's Accept header. Used by pipeline middleware (global exception handler, auth
+/// 401/403) which run outside MVC's content negotiation and would otherwise always emit JSON.
+/// </summary>
+public static class ErrorResponseWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private static readonly XmlSerializer XmlSerializer = new(typeof(ErrorResponse));
+
+    public static async Task WriteAsync(HttpContext context, ErrorResponse error)
+    {
+        context.Response.StatusCode = error.Status;
+
+        if (WantsXml(context.Request.Headers.Accept.ToString()))
+        {
+            context.Response.ContentType = "application/xml";
+            using var buffer = new MemoryStream();
+            XmlSerializer.Serialize(buffer, error);
+            buffer.Position = 0;
+            await buffer.CopyToAsync(context.Response.Body);
+        }
+        else
+        {
+            context.Response.ContentType = "application/problem+json";
+            await context.Response.WriteAsJsonAsync(error, JsonOptions);
+        }
+    }
+
+    // Prefer XML only when the client explicitly asks for it and does not also accept JSON.
+    private static bool WantsXml(string accept) =>
+        (accept.Contains("application/xml", StringComparison.OrdinalIgnoreCase)
+            || accept.Contains("text/xml", StringComparison.OrdinalIgnoreCase))
+        && !accept.Contains("application/json", StringComparison.OrdinalIgnoreCase);
+}

--- a/PassManAPI/Middleware/ExceptionHandlerMiddleware.cs
+++ b/PassManAPI/Middleware/ExceptionHandlerMiddleware.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Net;
-using System.Text.Json;
 using PassManAPI.DTOs;
 
 namespace PassManAPI.Middleware;
@@ -75,16 +74,8 @@ public class ExceptionHandlerMiddleware
             _ => CreateInternalServerError(exception, traceId)
         };
 
-        context.Response.ContentType = "application/problem+json";
-        context.Response.StatusCode = response.Status;
-
-        var options = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-        };
-
-        await context.Response.WriteAsJsonAsync(response, options);
+        // Content-negotiated (XML or JSON) so error bodies are available in both formats.
+        await ErrorResponseWriter.WriteAsync(context, response);
     }
 
     private ErrorResponse CreateInternalServerError(Exception exception, string traceId)

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ PassManGUI/
 
 PassManAPI.Tests/    # Integration tests
 └── *.cs            # 106 passing tests
+
+scripts/             # Test tooling
+├── PASSMAN-tests.postman_collection.json  # Postman smoke tests (full API surface)
+└── tester/          # Python test harness
 ```
 
 ## 📝 API Endpoints
@@ -258,6 +262,23 @@ dotnet test --filter "FullyQualifiedName~AuthEndpointsTests"
 - **InvitationTests**: Vault sharing workflows
 - **AttachmentModelTests**: File attachment handling
 - **AuthorizationPolicyTests**: Role-based access control
+
+### Postman smoke tests (end-to-end)
+
+`scripts/PASSMAN-tests.postman_collection.json` covers the full API surface against a live MySQL instance. Import it into Postman or run with Newman:
+
+```bash
+# API must be running in Test environment first
+ASPNETCORE_ENVIRONMENT=Test dotnet run --project PassManAPI
+
+# Then run the collection (Newman)
+npm install -g newman
+newman run scripts/PASSMAN-tests.postman_collection.json \
+  --env-var baseUrl=http://localhost:5248 \
+  --env-var userPassword=Password1!
+```
+
+Set `baseUrl` and `userPassword` in a Postman environment; all other variables (`userId`, `vaultId`, `credentialId`, …) are set automatically by the collection as it runs. See **[TESTING_GUIDE.md](/TESTING_GUIDE.md)** for full details.
 
 ## 📚 Documentation
 

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -56,6 +56,56 @@ dotnet test PassManAPI.Tests/PassManAPI.Tests.csproj
 - No direct DbContext calls; behaviors observed via HTTP (except seeding checks that use RoleManager via DI).
 - No real JWT/claim-based auth; only the dev header scheme for test runs.
 
+## Postman smoke tests (end-to-end)
+
+The collection `scripts/PASSMAN-tests.postman_collection.json` covers the full API surface against a live MySQL instance. It exercises every endpoint in order — auth, vaults, credentials, tags, invitations, vault shares, and audit — and is the primary way to verify the complete request/response cycle including content negotiation (JSON and XML).
+
+### Prerequisites
+- API running in **Test** environment on `http://localhost:5248`:
+  ```
+  ASPNETCORE_ENVIRONMENT=Test dotnet run --project PassManAPI
+  ```
+  The Test environment activates the `X-UserId` dev-header auth scheme. Without it, all requests will return 401.
+- A running **MySQL** instance (the collection hits a real DB, not SQLite in-memory).
+- Postman desktop app or Newman CLI.
+- A Postman environment with at least these variables set before the first run:
+  | Variable | Example value | Set by |
+  |---|---|---|
+  | `baseUrl` | `http://localhost:5248` | you |
+  | `userPassword` | `Password1!` | you |
+  | All others (`userId`, `vaultId`, `credentialId`, …) | _(any)_ | tests set them automatically |
+
+### How to run (Postman desktop)
+1. **Import**: File → Import → select `scripts/PASSMAN-tests.postman_collection.json`.
+2. **Select environment**: choose the environment containing `baseUrl` and `userPassword`.
+3. **Run**: open the Collection Runner, select the collection, and click **Run**.
+
+### How to run (Newman CLI)
+```bash
+npm install -g newman
+newman run scripts/PASSMAN-tests.postman_collection.json \
+  --env-var baseUrl=http://localhost:5248 \
+  --env-var userPassword=Password1!
+```
+
+### What the collection covers
+Each folder runs sequentially; later folders depend on IDs set by earlier ones.
+
+| Folder | Key assertions |
+|---|---|
+| **Auth** | Register, login, profile CRUD, password change, 2FA flow, role assignment |
+| **Vaults** | CRUD, 403 on foreign vaults, soft-delete cascade |
+| **Credentials** | CRUD, password retrieval, tag assignment (set/add/remove) |
+| **Tags** | CRUD, rename conflict, forbidden operations |
+| **Invitations** | Create, list, accept, revoke |
+| **VaultShares** | Share, update permission, revoke, forbidden |
+| **Audit** | Paginated log listing, single-log lookup, filters |
+
+### Notes
+- The collection creates its own smoke user (`smoke+{timestamp}@test.local`) on every run — no manual DB setup needed.
+- If a run stops early and leaves partial state (stale `vaultId`, etc.) clear the environment variables and start a fresh run.
+- JSON and XML content negotiation tests are included; responses are validated for both formats on key endpoints.
+
 ## Developer debugging tips
 - Check HTTP responses and payloads for `/api/auth/*`, `/api/vaults`, `/api/vaults/{id}/share`, `/api/vaults/{vaultId}/credentials`.
 - Headers: verify `Authorization` (dev token) and `X-UserId`.

--- a/scripts/PASSMAN-tests.postman_collection.json
+++ b/scripts/PASSMAN-tests.postman_collection.json
@@ -1,0 +1,5619 @@
+{
+  "info": {
+    "_postman_id": "e2c97322-c45f-483f-b90d-f0c8b32a2fd3",
+    "name": "PassManAPI - Full Endpoint Coverage Copy 9",
+    "description": "Comprehensive collection: positive and negative tests for Auth (expanded), Vaults, Credentials, Tags, Invitations, Audit. Run against Docker-local API at {{baseUrl}}.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "53985542",
+    "_collection_link": "https://go.postman.co/collection/53985542-e2c97322-c45f-483f-b90d-f0c8b32a2fd3?source=collection_link"
+  },
+  "event": [
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "var code = pm.response.code;",
+          "var contentType = (pm.response.headers.get('Content-Type') || '').toLowerCase();",
+          "var rawText = pm.response.text() || '';",
+          "var textLower = rawText.toLowerCase();",
+          "var requestUrl = pm.request && pm.request.url ? pm.request.url.toString() : '';",
+          "function safeJson(){ try { return pm.response.json(); } catch (e) { return null; } }",
+          "function hasStructuredError(obj){ return !!obj && typeof obj === 'object' && (obj.error !== undefined || obj.message !== undefined || obj.title !== undefined || obj.detail !== undefined || obj.errors !== undefined); }",
+          "function expectStructuredErrorResponse(label){",
+          "  pm.test(label + ' has a non-empty error body', function(){",
+          "    pm.expect(rawText.length).to.be.greaterThan(0);",
+          "  });",
+          "  pm.test(label + ' is structured JSON', function(){",
+          "    var body = safeJson();",
+          "    pm.expect(body).to.not.eql(null);",
+          "    pm.expect(hasStructuredError(body)).to.eql(true);",
+          "  });",
+          "}",
+          "if (code >= 400) {",
+          "  pm.test('hardening: error response is not html', function(){",
+          "    pm.expect(contentType.indexOf('text/html')).to.eql(-1);",
+          "    pm.expect(textLower.indexOf('<html')).to.eql(-1);",
+          "  });",
+          "}",
+          "if (contentType.indexOf('application/json') !== -1 || contentType.indexOf('application/problem+json') !== -1) {",
+          "  pm.test('hardening: json responses are parseable', function(){",
+          "    pm.expect(safeJson()).to.not.eql(null);",
+          "  });",
+          "}",
+          "if (code >= 500) {",
+          "  pm.test('hardening: no unhandled server errors', function(){",
+          "    pm.expect.fail('Unexpected 5xx response ' + code + ' for ' + requestUrl + ' body=' + rawText);",
+          "  });",
+          "}",
+          "if (code === 204) {",
+          "  pm.test('hardening: 204 response body is empty', function(){",
+          "    pm.expect(rawText.length).to.eql(0);",
+          "  });",
+          "}",
+          "if ((code === 200 || code === 201) && (contentType.indexOf('application/json') !== -1 || contentType.indexOf('application/problem+json') !== -1)) {",
+          "  pm.test('hardening: successful json responses are parseable', function(){",
+          "    pm.expect(safeJson()).to.not.eql(null);",
+          "  });",
+          "}",
+          "if (code === 400) {",
+          "  pm.test('hardening: 400 has non-empty payload', function(){",
+          "    pm.expect(rawText.length).to.be.greaterThan(0);",
+          "  });",
+          "  pm.test('hardening: 400 payload schema is valid', function(){",
+          "    var body = safeJson();",
+          "    if (contentType.indexOf('application/problem+json') !== -1) {",
+          "      pm.expect(body).to.be.an('object');",
+          "      pm.expect(body).to.have.property('title');",
+          "      pm.expect(body).to.have.property('status');",
+          "      pm.expect(body.status).to.eql(400);",
+          "      pm.expect(body).to.have.property('errors');",
+          "      pm.expect(body.errors).to.be.an('object');",
+          "    } else if (contentType.indexOf('application/json') !== -1 && body !== null) {",
+          "      if (typeof body === 'string') {",
+          "        pm.expect(body.length).to.be.greaterThan(0);",
+          "      } else {",
+          "        pm.expect(body).to.be.an('object');",
+          "        pm.expect(Object.keys(body).length).to.be.greaterThan(0);",
+          "        pm.expect(hasStructuredError(body)).to.eql(true);",
+          "      }",
+          "    }",
+          "  });",
+          "}",
+          "if (code === 404) {",
+          "  pm.test('hardening: 404 payload schema when body is present', function(){",
+          "    expectStructuredErrorResponse('404');",
+          "  });",
+          "}",
+          "if (code === 401 || code === 403) {",
+          "  pm.test('hardening: 401/403 body schema when present', function(){",
+          "    expectStructuredErrorResponse(code.toString());",
+          "  });",
+          "}",
+          "if (code === 404 && requestUrl.indexOf('/api/audit/logs') !== -1) {",
+          "  pm.test('hardening: audit 404 has structured error body when present', function(){",
+          "    if (rawText.length === 0) { return; }",
+          "    var body = safeJson();",
+          "    if (body && typeof body === 'object') {",
+          "      pm.expect(hasStructuredError(body)).to.eql(true);",
+          "    }",
+          "  });",
+          "}",
+          "if (code === 400 && requestUrl.indexOf('/api/audit/') !== -1) {",
+          "  pm.test('hardening: audit 400 has structured error body', function(){",
+          "    var body = safeJson();",
+          "    if (body && typeof body === 'object') {",
+          "      pm.expect(hasStructuredError(body)).to.eql(true);",
+          "    }",
+          "  });",
+          "}",
+          "if (requestUrl.indexOf('/api/auth/login') !== -1 && code === 401) {",
+          "  pm.test('hardening: auth login 401 message contract', function(){",
+          "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf('invalid credentials') !== -1 || x.indexOf('email not confirmed') !== -1; });",
+          "  });",
+          "}",
+          "if (requestUrl.indexOf('/api/auth/login') !== -1 && code === 423) {",
+          "  pm.test('hardening: auth login 423 message contract', function(){",
+          "    pm.expect(textLower).to.include('account is locked');",
+          "  });",
+          "}",
+          "if (requestUrl.indexOf('/api/auth/google') !== -1 && code === 400) {",
+          "  pm.test('hardening: google login 400 message contract', function(){",
+          "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf('invalid google token') !== -1 || x.indexOf('google login failed') !== -1; });",
+          "  });",
+          "}",
+          "if (requestUrl.indexOf('/api/vaults/') !== -1 && requestUrl.indexOf('/share') !== -1 && code === 404) {",
+          "  pm.test('hardening: vault share 404 message contract when body exists', function(){",
+          "    if (rawText.length === 0) { return; }",
+          "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf('vault not found') !== -1 || x.indexOf('target user not found') !== -1 || x.indexOf('share not found') !== -1; });",
+          "  });",
+          "}",
+          "if (requestUrl.indexOf('/api/invitations') !== -1 && (code === 400 || code === 404)) {",
+          "  pm.test('hardening: invitation error message contract', function(){",
+          "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf('invitation') !== -1 || x.indexOf('vault not found') !== -1 || x.indexOf('invalid role') !== -1 || x.indexOf('different email address') !== -1 || x.indexOf('not found') !== -1 || x.indexOf('permission') !== -1; });",
+          "  });",
+          "}"
+        ]
+      }
+    }
+  ],
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Auth - Register (201)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "pm.environment.set('timestamp', Date.now());",
+                  "pm.environment.set('userEmail', 'smoke+' + pm.environment.get('timestamp') + '@test.local');"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
+                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.user) pm.environment.set('userId', r.user.id || r.user.Id || ''); if(r && r.accessToken) pm.environment.set('accessToken', r.accessToken || r.AccessToken || ''); }catch(e){} }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"smoke+{{timestamp}}@test.local\",\n  \"password\": \"{{userPassword}}\",\n  \"confirmPassword\": \"{{userPassword}}\",\n  \"userName\": \"smokeuser{{timestamp}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/register",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "register"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Register Missing Email (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
+                  "pm.test('contains email', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('email'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"password\": \"Password1!\", \"confirmPassword\": \"Password1!\", \"userName\": \"x\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/register",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "register"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Register Password Mismatch (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
+                  "pm.test('contains password mismatch/validation message', function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes('password') || x.includes('confirm') || x.includes('match') || x.includes('validation'); }); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"badpw+{{timestamp}}@test.local\", \"password\": \"Password1!\", \"confirmPassword\": \"Different1!\", \"userName\": \"x\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/register",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "register"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Login (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
+                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.accessToken) pm.environment.set('accessToken', r.accessToken || r.AccessToken || ''); if(r && r.user) pm.environment.set('userId', r.user.id || r.user.Id || ''); }catch(e){} }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"{{userEmail}}\", \"password\": \"{{userPassword}}\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Login Missing Fields (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Login Invalid Credentials (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });",
+                  "pm.test('contains invalid credentials message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('invalid credentials'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"no-such-user@test.local\", \"password\": \"wrong\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Login Locked (423)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "var baseUrl = pm.variables.get('baseUrl');",
+                  "var email = pm.variables.get('userEmail');",
+                  "var wrongPassword = 'WrongLockout123!';",
+                  "for (var i = 0; i < 5; i++) {",
+                  "  pm.sendRequest({",
+                  "    url: baseUrl + '/api/auth/login',",
+                  "    method: 'POST',",
+                  "    header: { 'Content-Type': 'application/json' },",
+                  "    body: { mode: 'raw', raw: JSON.stringify({ email: email, password: wrongPassword }) }",
+                  "  }, function () {});",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 or 423 while lockout state settles', function(){ pm.expect([401,423]).to.include(pm.response.code); });",
+                  "pm.test('contains invalid credentials or account locked message', function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes('invalid credentials') || x.includes('account is locked'); }); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"{{userEmail}}\", \"password\": \"wrong1\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Google Invalid Token (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
+                  "pm.test('contains google token error message', function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes('invalid google token') || x.includes('google login failed'); }); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"idToken\": \"invalid-token\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/google",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "google"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Me Get Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "me"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Me Get (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "me"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Update Profile Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"userName\": \"x\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "me"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Update Profile BadRequest (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
+                  "pm.test('contains email validation', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('email'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"not-an-email\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "me"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Update Profile (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"userName\": \"updated-{{timestamp}}\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "me"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Delete Account Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "me"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Delete Account NotFound (404)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "var baseUrl = pm.variables.get('baseUrl');",
+                  "var ts = Date.now();",
+                  "var email = 'deleted+' + ts + '@test.local';",
+                  "var password = pm.variables.get('userPassword') || 'Password1!';",
+                  "var registerPayload = { email: email, password: password, confirmPassword: password, userName: 'deleted' + ts };",
+                  "pm.sendRequest({",
+                  "  url: baseUrl + '/api/auth/register',",
+                  "  method: 'POST',",
+                  "  header: { 'Content-Type': 'application/json' },",
+                  "  body: { mode: 'raw', raw: JSON.stringify(registerPayload) }",
+                  "}, function (err, res) {",
+                  "  if (err || !res || res.code !== 201) { return; }",
+                  "  var body = {};",
+                  "  try { body = res.json(); } catch (e) {}",
+                  "  var token = body.accessToken || '';",
+                  "  if (!token) { return; }",
+                  "  pm.environment.set('deletedAccessToken', token);",
+                  "  pm.sendRequest({",
+                  "    url: baseUrl + '/api/auth/me',",
+                  "    method: 'DELETE',",
+                  "    header: { Authorization: 'Bearer ' + token }",
+                  "  }, function () {});",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains user not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('user not found'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{deletedAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "me"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Permissions Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/permissions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "permissions"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Permissions (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/permissions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "permissions"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Assign Role Forbidden (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
+                  "pm.test('forbidden/unauthorized message present', function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } else { pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('unauthorized') || x.length === 0; }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"userId\": 999999, \"role\": \"Admin\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/assign-role",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "assign-role"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Assign Role BadRequest (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
+                  "pm.test('contains role does not exist message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('does not exist'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{adminUserId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"userId\": {{userId}}, \"role\": \"NonExistentRole\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/assign-role",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "assign-role"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Assign Role NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains user not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('user not found'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{adminUserId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"userId\": 999999, \"role\": \"Admin\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/assign-role",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "assign-role"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Assign Role (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{adminUserId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"userId\": {{userId}}, \"role\": \"VaultOwner\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/assign-role",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "assign-role"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Auth - Assign Role Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer invalid_token"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"userId\": {{userId}}, \"role\": \"User\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/assign-role",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "assign-role"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Users",
+      "item": [
+        {
+          "name": "Users - List Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/user",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - List Forbidden (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
+                  "pm.test('if 403 then forbidden message', function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - List (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
+                  "pm.test('if 403 then forbidden message', function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{adminUserId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/{{userId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "{{userId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get Forbidden/NotFound (403|404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
+                  "pm.test('contains expected get-user error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('user not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
+                  "pm.test('contains forbidden message when present', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('permission'); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/{{userId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "{{userId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Update Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"x\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/user/{{userId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "{{userId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Update BadRequest (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"not-an-email\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/user/{{userId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "{{userId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Update Forbidden/NotFound (403|404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
+                  "pm.test('contains expected update-user error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('user not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"x@test.local\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/user/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Update (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
+                  "pm.environment.set('userEmail', 'updated+' + pm.environment.get('timestamp') + '@test.local');"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"updated+{{timestamp}}@test.local\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/user/{{userId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "{{userId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Delete Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/{{userId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "{{userId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Delete Forbidden/NotFound (403|404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
+                  "pm.test('contains expected delete-user error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('user not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get Vaults Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/{{userId}}/vaults",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "{{userId}}",
+                "vaults"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get Vaults Forbidden/NotFound (403|404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
+                  "pm.test('contains expected get-vaults error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('user not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/999999/vaults",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "999999",
+                "vaults"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get Vaults Forbidden (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
+                  "pm.test('contains forbidden message when present', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('permission'); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/999999/vaults",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "999999",
+                "vaults"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get Vaults (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/{{userId}}/vaults",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "{{userId}}",
+                "vaults"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get Tags Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/{{userId}}/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "{{userId}}",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get Tags Forbidden/NotFound (403|404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
+                  "pm.test('contains expected get-tags error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('user not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/999999/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "999999",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get Tags Forbidden (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/999999/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "999999",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Users - Get Tags (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/user/{{userId}}/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "user",
+                "{{userId}}",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Vaults",
+      "item": [
+        {
+          "name": "Vaults - Create Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"noauth\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Vaults - Create BadRequest (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
+                  "pm.test('contains validation details', function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes('validation') || x.includes('errors') || x.includes('required') || x.includes('invalid or unauthorized tag ids'); }); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Vaults - Create (201)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
+                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('vaultId', r.id); }catch(e){} }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"Smoke Vault {{timestamp}}\", \"userId\": {{userId}} }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Vaults - List (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Vaults - Get (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Vaults - Update (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"Updated Vault {{timestamp}}\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Vaults - Create For Deletion (201)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
+                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('deleteVaultId', r.id); }catch(e){} }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"TempDeleteVault {{timestamp}}\", \"userId\": {{userId}} }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Vaults - Delete (204)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{deleteVaultId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{deleteVaultId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Vaults - Delete NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains vault not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('vault not found'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/999998",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "999998"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Credentials",
+      "item": [
+        {
+          "name": "Credentials - List Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/1/credentials",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "1",
+                "credentials"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - List Forbidden/NotFound (403|404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 or 404 (vault does not belong to user or does not exist)', function(){ pm.expect(pm.response.code).to.be.oneOf([403, 404]); });",
+                  "pm.test('contains expected list-credentials error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 403){ pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('not found') || x.length === 0; }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/999999/credentials",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "999999",
+                "credentials"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - List (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "credentials"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Create Missing Password (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"title\": \"NoPass\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "credentials"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Create NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains vault not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('vault not found'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"title\": \"NoPerm\", \"encryptedPassword\": \"x\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/999999/credentials",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "999999",
+                "credentials"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Create (201)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
+                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('credentialId', r.id); }catch(e){} }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"title\": \"Smoke Credential {{timestamp}}\", \"encryptedPassword\": \"s3cret\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "credentials"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Get Password Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/1/password",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "1",
+                "password"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Get Password NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/999999/password",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "999999",
+                "password"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Get Password Forbidden/NotFound (403|404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/password",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}",
+                "password"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Get Password (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
+                  "pm.test('has password', function(){ try{ var j = JSON.parse(pm.response.text()); pm.expect(j).to.have.property('password'); }catch(e){ pm.expect.fail('response not json or empty'); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/password",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}",
+                "password"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Update Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"title\": \"x\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Update NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"title\": \"x\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Update Forbidden (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"title\": \"x\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Update BadRequest (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Update (204)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"title\": \"Updated Title {{timestamp}}\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Update Password BadRequest (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/password",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}",
+                "password"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Update Password (204)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"encryptedPassword\": \"newpass\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/password",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}",
+                "password"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Delete Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Delete NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Delete NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains credential not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('credential not found'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/999998",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "999998"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Create For Deletion (201)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
+                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('deleteCredentialId', r.id); }catch(e){} }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"title\": \"TempDeleteCred {{timestamp}}\", \"encryptedPassword\": \"s3cret\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "credentials"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Delete (204)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{deleteCredentialId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{deleteCredentialId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Get Tags Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/1/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "1",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Get Tags NotFound/Forbidden (404|403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains expected get-tags error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.satisfy(function(x){ return x.includes('credential not found') || x.includes('not found'); }); } else { pm.expect(t).to.include('permission'); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/999997/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "999997",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Get Tags (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Setup Create Tag (201)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
+                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('credTagId', r.id); }catch(e){} }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"cred-tag-{{timestamp}}\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Set Tags BadRequest (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"tagIds\": [999999] }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Set Tags (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
+                  "pm.test('returns array of tags', function(){ pm.expect(pm.response.json()).to.be.an('array'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"tagIds\": [{{credTagId}}] }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Add Tag BadRequest/NotFound (400|404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains expected add-tag error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.satisfy(function(x){ return x.includes('tag not found') || x.includes('credential not found'); }); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('tag does not belong') || x.includes('already assigned'); }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}",
+                "tags",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Setup Create Second Tag (201)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
+                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('credTagId2', r.id); }catch(e){} }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"cred-tag2-{{timestamp}}\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Add Tag (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
+                  "pm.test('returns tag added message', function(){ var b = pm.response.json(); pm.expect(b).to.have.property('message'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags/{{credTagId2}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}",
+                "tags",
+                "{{credTagId2}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Remove Tag NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains tag assignment not found message', function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes('not assigned to this credential') || x.includes('credential not found'); }); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}",
+                "tags",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Remove Tag CredentialNotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains credential not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('credential not found'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/999999/tags/1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "999999",
+                "tags",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Credentials - Remove Tag (204)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags/{{credTagId2}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "credentials",
+                "{{credentialId}}",
+                "tags",
+                "{{credTagId2}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Tags",
+      "item": [
+        {
+          "name": "Tags - List Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - List (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Get Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/tags/{{tagId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags",
+                "{{tagId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Get NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains not found message when present', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('not found'); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/tags/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Get (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/tags/{{tagId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags",
+                "{{tagId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Create Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"noauth\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Create BadRequest (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Create (201)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
+                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('tagId', r.id); }catch(e){} }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"smoke-tag-{{timestamp}}\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Create Duplicate (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
+                  "pm.test('contains duplicate tag message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('already exists'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"smoke-tag-{{timestamp}}\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Update Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"x\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tags/1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Update NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"x\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tags/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Setup Create Conflict Tag",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// 201 on first run, 400 if tag already exists — both are fine"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"existing-name\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tags",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Update Forbidden or BadRequest (403|400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
+                  "pm.test('contains duplicate tag message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('already exists'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"existing-name\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tags/{{tagId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags",
+                "{{tagId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Update (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"name\": \"renamed-{{timestamp}}\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tags/{{tagId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags",
+                "{{tagId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Delete Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/tags/1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Delete NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/tags/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Delete Forbidden (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/tags/999998",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags",
+                "999998"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Tags - Delete (204)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/tags/{{tagId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "tags",
+                "{{tagId}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Invitations",
+      "item": [
+        {
+          "name": "Invitations - Create Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"invitee@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"View\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Create VaultNotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"invitee@test.local\", \"vaultId\": 999999, \"role\": \"View\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Create Forbid (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"invitee@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"View\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Create BadRequest (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"invitee+{{timestamp}}@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"NotARole\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Create (201)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
+                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('invitationId', r.id); if(r && r.inviteToken) pm.environment.set('inviteToken', r.inviteToken); }catch(e){} }"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"email\": \"invitee+{{timestamp}}@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"View\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - List Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - List (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Accept Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations/invalid_token/accept",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations",
+                "invalid_token",
+                "accept"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Accept NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations/no-such-token/accept",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations",
+                "no-such-token",
+                "accept"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Accept BadRequest (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
+                  "pm.test('contains invitation mismatch/not found message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('invitation not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('different email address') || x.includes('cannot'); }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations/{{inviteToken}}/accept",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations",
+                "{{inviteToken}}",
+                "accept"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Accept (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations/{{inviteToken}}/accept",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations",
+                "{{inviteToken}}",
+                "accept"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Revoke Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations/1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Revoke NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains not found message when present', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('not found'); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Revoke Forbidden (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations/999998",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations",
+                "999998"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Invitations - Revoke (204)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/invitations/{{invitationId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "invitations",
+                "{{invitationId}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "VaultShares",
+      "item": [
+        {
+          "name": "VaultShares - Share Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"userEmail\": \"noone@test.local\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "share"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "VaultShares - Share BadRequest (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "share"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "VaultShares - Share NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"userEmail\": \"noone@test.local\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/999999/share",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "999999",
+                "share"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "VaultShares - Share Forbidden (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"userEmail\": \"noone@test.local\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "share"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "VaultShares - Share (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('404 contains target user not found message', function(){ if(pm.response.code === 404){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('target user not found') || x.includes('vault not found'); }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{ \"userEmail\": \"invitee+{{timestamp}}@test.local\" }"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "share"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "VaultShares - Revoke Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share/{{userId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "share",
+                "{{userId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "VaultShares - Revoke NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains share not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('share not found') || x.includes('vault not found'); }); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "share",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "VaultShares - Revoke Forbidden (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share/{{userId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "share",
+                "{{userId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "VaultShares - Revoke (204)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "var baseUrl = pm.variables.get('baseUrl');",
+                  "var vaultId = pm.variables.get('vaultId');",
+                  "var ownerEmail = pm.variables.get('userEmail');",
+                  "var ownerId = pm.variables.get('userId');",
+                  "pm.sendRequest({",
+                  "  url: baseUrl + '/api/vaults/' + vaultId + '/share',",
+                  "  method: 'POST',",
+                  "  header: { 'Content-Type': 'application/json', 'X-UserId': String(ownerId) },",
+                  "  body: { mode: 'raw', raw: JSON.stringify({ userEmail: ownerEmail }) }",
+                  "}, function () {});"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share/{{userId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "vaults",
+                "{{vaultId}}",
+                "share",
+                "{{userId}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Audit",
+      "item": [
+        {
+          "name": "Audit - Get My Logs Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Audit - Get My Logs (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Audit - Get Log By Id Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs/1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Audit - Get Log By Id Forbidden/NotFound (403|404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 or 404 (log belongs to another user or does not exist)', function(){ pm.expect(pm.response.code).to.be.oneOf([403, 404]); });",
+                  "pm.test('contains expected get-log-by-id error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('audit log not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Audit - Get Log By Id NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains audit log not found error message', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('audit log not found'); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Audit - Get Vault Logs Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs/vault/{{vaultId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs",
+                "vault",
+                "{{vaultId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Audit - Get Vault Logs NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains vault not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('vault not found'); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs/vault/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs",
+                "vault",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Audit - Get Vault Logs NotFound (404)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
+                  "pm.test('contains vault not found error message', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('vault not found'); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs/vault/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs",
+                "vault",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Audit - Get Vault Logs (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs/vault/{{vaultId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs",
+                "vault",
+                "{{vaultId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Audit - Get All Logs Unauthorized (401)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs",
+                "all"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Audit - Get All Logs (200)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{adminUserId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs",
+                "all"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Audit - Get All Logs Forbidden (403)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
+                  "pm.test('if 403 then forbidden message', function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "X-UserId",
+                "value": "{{userId}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/audit/logs/all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "audit",
+                "logs",
+                "all"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:5246"
+    },
+    {
+      "key": "timestamp",
+      "value": ""
+    },
+    {
+      "key": "userEmail",
+      "value": ""
+    },
+    {
+      "key": "userPassword",
+      "value": "Password1!"
+    },
+    {
+      "key": "userId",
+      "value": ""
+    },
+    {
+      "key": "accessToken",
+      "value": ""
+    },
+    {
+      "key": "adminUserId",
+      "value": "1"
+    },
+    {
+      "key": "vaultId",
+      "value": ""
+    },
+    {
+      "key": "credentialId",
+      "value": ""
+    },
+    {
+      "key": "tagId",
+      "value": ""
+    },
+    {
+      "key": "invitationId",
+      "value": ""
+    }
+  ]
+}
+
+
+


### PR DESCRIPTION
Closes #178. Implements the professor's requirement: *"When errors are returned, have possibilities for both XML and JSON."*

## Problem
Every error path was effectively **JSON-only**:
- `ControllerErrorExtensions.Error` hard-coded `ContentTypes = { "application/problem+json" }`.
- `ExceptionHandlerMiddleware` and `AuthErrorBodyMiddleware` called `WriteAsJsonAsync`.
- `ErrorResponse.Errors` (a `Dictionary`) is `[XmlIgnore]`, so validation field errors couldn't appear in XML even if negotiated.

So a client sending `Accept: application/xml` still got JSON for 400/401/403/404/409/500.

## Fix
- **`ErrorResponse`**: added an XML-serializable `ValidationErrors` list that mirrors the JSON `errors` object (plus a `ValidationError` type), so field-level errors now serialize in both formats. JSON shape is unchanged.
- **`ControllerErrorExtensions.Error`**: removed the forced content type → MVC content-negotiates JSON/XML from `Accept`.
- **`ErrorResponseWriter`** (new): content-negotiates `ErrorResponse` for the pipeline middlewares (which run outside MVC negotiation).
- **`ExceptionHandlerMiddleware`** + **`AuthErrorBodyMiddleware`** now use it.

## Verification
- New tests: controller 404 → `application/xml`, middleware 401 → `application/xml`, default → JSON.
- `docker compose --profile test run --rm test` → **112/112 pass**.

Note: JSON error bodies are unchanged in shape; controller errors now return `application/json` (instead of `application/problem+json`) when JSON is negotiated — both are accepted by the test collections.