### PR TITLE
feat: XML on every endpoint + how-to-send-XML docs (#180)

### DIFF
--- a/PassManAPI.Tests/CredentialsEndpointsTests.cs
+++ b/PassManAPI.Tests/CredentialsEndpointsTests.cs
@@ -201,6 +201,87 @@ public class CredentialsEndpointsTests : IClassFixture<TestWebApplicationFactory
     }
 
     [Fact]
+    public async Task Owner_Can_Get_Credential_By_Id()
+    {
+        var user = await RegisterAsync("cred-getbyid@test.local");
+
+        var vaultReq = new HttpRequestMessage(HttpMethod.Post, "/api/vaults")
+        {
+            Content = JsonContent.Create(new { name = "GetById Vault", userId = user.User.Id })
+        };
+        vaultReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        var vaultResp = await _client.SendAsync(vaultReq);
+        vaultResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var vault = await vaultResp.Content.ReadFromJsonAsync<CreatedVaultResponse>();
+
+        var credReq = new HttpRequestMessage(HttpMethod.Post, $"/api/vaults/{vault!.Id}/credentials")
+        {
+            Content = JsonContent.Create(new
+            {
+                Title = "GetById Cred",
+                Username = "gbuser",
+                EncryptedPassword = "secret123",
+                Url = "https://example.com",
+                Notes = "some notes"
+            })
+        };
+        credReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        var credResp = await _client.SendAsync(credReq);
+        credResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await credResp.Content.ReadFromJsonAsync<IdResponse>();
+
+        var getReq = new HttpRequestMessage(HttpMethod.Get, $"/api/credentials/{created!.Id}");
+        getReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        var getResp = await _client.SendAsync(getReq);
+        getResp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var detail = await getResp.Content.ReadFromJsonAsync<CredentialDetail>();
+        detail.Should().NotBeNull();
+        detail!.Id.Should().Be(created.Id);
+        detail.Title.Should().Be("GetById Cred");
+        detail.Username.Should().Be("gbuser");
+        detail.Notes.Should().Be("some notes");
+        detail.VaultId.Should().Be(vault.Id);
+    }
+
+    [Fact]
+    public async Task GetCredentialById_Returns_404_For_Missing_Credential()
+    {
+        var user = await RegisterAsync("cred-getbyid-404@test.local");
+
+        var getReq = new HttpRequestMessage(HttpMethod.Get, "/api/credentials/999999");
+        getReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        var getResp = await _client.SendAsync(getReq);
+        getResp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetCredentialById_Returns_403_For_Other_Users_Credential()
+    {
+        var owner = await RegisterAsync("cred-getbyid-owner@test.local");
+        var other = await RegisterAsync("cred-getbyid-other@test.local");
+
+        var vaultReq = new HttpRequestMessage(HttpMethod.Post, "/api/vaults")
+        {
+            Content = JsonContent.Create(new { name = "Private Vault", userId = owner.User.Id })
+        };
+        vaultReq.Headers.Add("X-UserId", owner.User.Id.ToString());
+        var vault = await (await _client.SendAsync(vaultReq)).Content.ReadFromJsonAsync<CreatedVaultResponse>();
+
+        var credReq = new HttpRequestMessage(HttpMethod.Post, $"/api/vaults/{vault!.Id}/credentials")
+        {
+            Content = JsonContent.Create(new { Title = "Private Cred", EncryptedPassword = "secret" })
+        };
+        credReq.Headers.Add("X-UserId", owner.User.Id.ToString());
+        var created = await (await _client.SendAsync(credReq)).Content.ReadFromJsonAsync<IdResponse>();
+
+        var getReq = new HttpRequestMessage(HttpMethod.Get, $"/api/credentials/{created!.Id}");
+        getReq.Headers.Add("X-UserId", other.User.Id.ToString());
+        var getResp = await _client.SendAsync(getReq);
+        getResp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
     public async Task Owner_Can_Retrieve_Decrypted_Password()
     {
         var user = await RegisterAsync("cred-password-get@test.local");
@@ -342,6 +423,20 @@ public class CredentialsEndpointsTests : IClassFixture<TestWebApplicationFactory
     }
 
     private record CreatedVaultResponse(int Id);
+
+    private record CredentialDetail(
+        int Id,
+        string Title,
+        string? Username,
+        string? Url,
+        string? Notes,
+        int? CategoryId,
+        string? CategoryName,
+        int VaultId,
+        DateTime CreatedAt,
+        DateTime? UpdatedAt,
+        DateTime? LastAccessed
+    );
 
     private record CredentialListItem(
         int Id,

--- a/PassManAPI.Tests/XmlSerializationTests.cs
+++ b/PassManAPI.Tests/XmlSerializationTests.cs
@@ -342,6 +342,40 @@ public class XmlSerializationTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task GetCredentialById_Should_Return_XML_When_Accept_Is_XML()
+    {
+        var user = await RegisterAsync($"credbyid-xml-{Guid.NewGuid()}@test.local");
+
+        var vReq = new HttpRequestMessage(HttpMethod.Post, "/api/vaults")
+        {
+            Content = JsonContent.Create(new { name = "credbyid-vault", userId = user.User.Id })
+        };
+        vReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        var vaultId = (await (await _client.SendAsync(vReq)).Content.ReadFromJsonAsync<CreatedVaultResponse>())!.Id;
+
+        var cReq = new HttpRequestMessage(HttpMethod.Post, $"/api/vaults/{vaultId}/credentials")
+        {
+            Content = JsonContent.Create(new { title = "xml-detail-cred", encryptedPassword = "pw", notes = "my notes" })
+        };
+        cReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        var credId = (await (await _client.SendAsync(cReq)).Content.ReadFromJsonAsync<CreatedVaultResponse>())!.Id;
+
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/credentials/{credId}");
+        req.Headers.Add("X-UserId", user.User.Id.ToString());
+        req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
+        var resp = await _client.SendAsync(req);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        var body = await resp.Content.ReadAsStringAsync();
+        var xml = XDocument.Parse(body);
+        xml.Root!.Name.LocalName.Should().Be("CredentialDto");
+        xml.Root.Element("Title")!.Value.Should().Be("xml-detail-cred");
+        xml.Root.Element("Notes")!.Value.Should().Be("my notes");
+        xml.Root.Element("VaultId")!.Value.Should().Be(vaultId.ToString());
+    }
+
+    [Fact]
     public async Task AuditLogs_Should_Return_XML_When_Accept_Is_XML()
     {
         // Covers the IEnumerable -> List fix on PaginatedAuditResult.Items.

--- a/PassManAPI.Tests/XmlSerializationTests.cs
+++ b/PassManAPI.Tests/XmlSerializationTests.cs
@@ -227,6 +227,94 @@ public class XmlSerializationTests : IClassFixture<TestWebApplicationFactory>
         payload!.User.Email.Should().Be(registerRequest.Email);
     }
 
+    [Fact]
+    public async Task GetTags_Should_Return_XML_When_Accept_Is_XML()
+    {
+        // Covers the record->class fix for TagDto (positional records aren't XmlSerializable).
+        var user = await RegisterAsync($"tags-xml-{Guid.NewGuid()}@test.local");
+
+        var create = new HttpRequestMessage(HttpMethod.Post, "/api/tags")
+        {
+            Content = JsonContent.Create(new { name = "xml-tag" })
+        };
+        create.Headers.Add("X-UserId", user.User.Id.ToString());
+        (await _client.SendAsync(create)).StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var req = new HttpRequestMessage(HttpMethod.Get, "/api/tags");
+        req.Headers.Add("X-UserId", user.User.Id.ToString());
+        req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
+        var resp = await _client.SendAsync(req);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        var body = await resp.Content.ReadAsStringAsync();
+        XDocument.Parse(body).Root!.Name.LocalName.Should().Be("ArrayOfTagDto");
+        body.Should().Contain("<Name>xml-tag</Name>");
+    }
+
+    [Fact]
+    public async Task Credentials_List_And_Password_Should_Return_XML_When_Accept_Is_XML()
+    {
+        // Covers the anonymous-type -> named-DTO fix (CredentialListItemDto, PasswordResponse).
+        var user = await RegisterAsync($"creds-xml-{Guid.NewGuid()}@test.local");
+
+        var vReq = new HttpRequestMessage(HttpMethod.Post, "/api/vaults")
+        {
+            Content = JsonContent.Create(new { name = "xml-vault", userId = user.User.Id })
+        };
+        vReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        var vaultId = (await (await _client.SendAsync(vReq)).Content.ReadFromJsonAsync<CreatedVaultResponse>())!.Id;
+
+        var cReq = new HttpRequestMessage(HttpMethod.Post, $"/api/vaults/{vaultId}/credentials")
+        {
+            Content = JsonContent.Create(new { title = "xml-cred", encryptedPassword = "secret" })
+        };
+        cReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        var credId = (await (await _client.SendAsync(cReq)).Content.ReadFromJsonAsync<CreatedVaultResponse>())!.Id;
+
+        var listReq = new HttpRequestMessage(HttpMethod.Get, $"/api/vaults/{vaultId}/credentials");
+        listReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        listReq.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
+        var listResp = await _client.SendAsync(listReq);
+        listResp.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        XDocument.Parse(await listResp.Content.ReadAsStringAsync())
+            .Root!.Name.LocalName.Should().Be("ArrayOfCredentialListItemDto");
+
+        var pwReq = new HttpRequestMessage(HttpMethod.Get, $"/api/credentials/{credId}/password");
+        pwReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        pwReq.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
+        var pwResp = await _client.SendAsync(pwReq);
+        pwResp.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        var pwBody = await pwResp.Content.ReadAsStringAsync();
+        XDocument.Parse(pwBody).Root!.Name.LocalName.Should().Be("PasswordResponse");
+        pwBody.Should().Contain("<Password>secret</Password>");
+    }
+
+    [Fact]
+    public async Task AuditLogs_Should_Return_XML_When_Accept_Is_XML()
+    {
+        // Covers the IEnumerable -> List fix on PaginatedAuditResult.Items.
+        var user = await RegisterAsync($"audit-xml-{Guid.NewGuid()}@test.local");
+
+        // Creating a vault writes an audit log entry for this user.
+        var vReq = new HttpRequestMessage(HttpMethod.Post, "/api/vaults")
+        {
+            Content = JsonContent.Create(new { name = "audit-vault", userId = user.User.Id })
+        };
+        vReq.Headers.Add("X-UserId", user.User.Id.ToString());
+        (await _client.SendAsync(vReq)).EnsureSuccessStatusCode();
+
+        var req = new HttpRequestMessage(HttpMethod.Get, "/api/audit/logs");
+        req.Headers.Add("X-UserId", user.User.Id.ToString());
+        req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
+        var resp = await _client.SendAsync(req);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        XDocument.Parse(await resp.Content.ReadAsStringAsync())
+            .Root!.Name.LocalName.Should().Be("PaginatedAuditResult");
+    }
+
     private async Task<AuthResponse> RegisterAsync(string email)
     {
         var request = new RegisterRequest

--- a/PassManAPI/Controllers/AuthController.cs
+++ b/PassManAPI/Controllers/AuthController.cs
@@ -428,7 +428,7 @@ public class AuthController : ControllerBase
             return this.BadRequestProblem(string.Join(", ", result.Errors.Select(e => e.Description)));
         }
 
-        return Ok(new { Message = $"User assigned to role '{request.RoleName}' successfully." });
+        return Ok(new MessageResponse { Message = $"User assigned to role '{request.RoleName}' successfully." });
     }
 
     /// <summary>

--- a/PassManAPI/Controllers/CredentialsController.cs
+++ b/PassManAPI/Controllers/CredentialsController.cs
@@ -57,15 +57,15 @@ public class CredentialsController : ControllerBase
             .Where(c => c.VaultId == vaultId)
             .Include(c => c.CredentialTags)
                 .ThenInclude(ct => ct.Tag)
-            .Select(c => new
+            .Select(c => new CredentialListItemDto
             {
-                c.Id,
-                c.Title,
-                c.Username,
-                c.Url,
-                c.CreatedAt,
-                c.UpdatedAt,
-                c.LastAccessed,
+                Id = c.Id,
+                Title = c.Title,
+                Username = c.Username,
+                Url = c.Url,
+                CreatedAt = c.CreatedAt,
+                UpdatedAt = c.UpdatedAt,
+                LastAccessed = c.LastAccessed,
                 Tags = c.CredentialTags.Select(ct => new TagDto(ct.Tag.Id, ct.Tag.Name)).ToList()
             })
             .ToListAsync();
@@ -136,7 +136,7 @@ public class CredentialsController : ControllerBase
         _db.Credentials.Add(credential);
         await _db.SaveChangesAsync();
 
-        return Created($"/api/vaults/{vaultId}/credentials/{credential.Id}", new { credential.Id });
+        return Created($"/api/vaults/{vaultId}/credentials/{credential.Id}", new IdResponse { Id = credential.Id });
     }
 
     /// <summary>
@@ -188,7 +188,7 @@ public class CredentialsController : ControllerBase
         if (parts.Length != 2)
         {
             // Handle legacy format (unencrypted)
-            return Ok(new { password = credential.EncryptedPassword });
+            return Ok(new PasswordResponse { Password = credential.EncryptedPassword });
         }
 
         var perCredentialKeyBase64 = parts[0];
@@ -200,7 +200,7 @@ public class CredentialsController : ControllerBase
         // Decrypt the password
         var decryptedPassword = _encryptionService.DecryptPassword(encryptedPasswordBytes, perCredentialKey);
 
-        return Ok(new { password = decryptedPassword });
+        return Ok(new PasswordResponse { Password = decryptedPassword });
     }
 
     /// <summary>
@@ -529,7 +529,7 @@ public class CredentialsController : ControllerBase
         _db.CredentialTags.Add(new CredentialTag(id, tagId));
         await _db.SaveChangesAsync();
 
-        return Ok(new { message = "Tag added successfully." });
+        return Ok(new MessageResponse { Message = "Tag added successfully." });
     }
 
     /// <summary>

--- a/PassManAPI/Controllers/CredentialsController.cs
+++ b/PassManAPI/Controllers/CredentialsController.cs
@@ -140,6 +140,65 @@ public class CredentialsController : ControllerBase
     }
 
     /// <summary>
+    /// Retrieves a single credential by its ID (without the password).
+    /// </summary>
+    /// <param name="id">The unique identifier of the credential.</param>
+    /// <response code="200">Returns the credential detail.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    /// <response code="403">If the user does not have access to the vault that owns this credential.</response>
+    /// <response code="404">If the credential with the specified ID is not found.</response>
+    [HttpGet("/api/credentials/{id:int}")]
+    [Authorize(Policy = PermissionConstants.CredentialRead)]
+    [ProducesResponseType(typeof(CredentialDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetById(int id)
+    {
+        if (!User.TryGetCurrentUserId(out var currentUserId))
+        {
+            return this.UnauthorizedProblem();
+        }
+
+        var credential = await _db.Credentials
+            .AsNoTracking()
+            .Include(c => c.Category)
+            .Include(c => c.CredentialTags)
+                .ThenInclude(ct => ct.Tag)
+            .FirstOrDefaultAsync(c => c.Id == id);
+
+        if (credential is null)
+        {
+            return this.NotFoundProblem("Credential not found.");
+        }
+
+        var canAccess = await CanAccessVault(credential.VaultId, currentUserId);
+        if (!canAccess)
+        {
+            return this.ForbiddenProblem();
+        }
+
+        var dto = new CredentialDto
+        {
+            Id = credential.Id,
+            Title = credential.Title,
+            Username = credential.Username,
+            Url = credential.Url,
+            Notes = credential.Notes,
+            CategoryId = credential.CategoryId,
+            CategoryName = credential.Category?.Name,
+            VaultId = credential.VaultId,
+            CreatedAt = credential.CreatedAt,
+            UpdatedAt = credential.UpdatedAt,
+            LastAccessed = credential.LastAccessed,
+            Tags = credential.CredentialTags
+                .Select(ct => new TagDto(ct.Tag.Id, ct.Tag.Name))
+                .ToList()
+        };
+
+        return Ok(dto);
+    }
+
+    /// <summary>
     /// Retrieves the decrypted password for a specific credential.
     /// </summary>
     /// <remarks>

--- a/PassManAPI/Controllers/InvitationsController.cs
+++ b/PassManAPI/Controllers/InvitationsController.cs
@@ -119,7 +119,7 @@ namespace PassManAPI.Controllers
                 Status = "Pending",
                 ExpiresAt = i.ExpiresAt,
                 InviteToken = i.InviteToken
-            }));
+            }).ToList());
         }
 
         // POST: api/invitations/{token}/accept
@@ -188,7 +188,7 @@ namespace PassManAPI.Controllers
 
             await _context.SaveChangesAsync();
 
-            return Ok(new { Message = "Invitation accepted.", VaultId = invitation.VaultId });
+            return Ok(new InvitationAcceptedResponse { Message = "Invitation accepted.", VaultId = invitation.VaultId });
         }
 
         // DELETE: api/invitations/{id}

--- a/PassManAPI/Controllers/UserController.cs
+++ b/PassManAPI/Controllers/UserController.cs
@@ -43,7 +43,8 @@ public class UserController : ControllerBase
             .OrderBy(u => u.Email)
             .ToListAsync();
 
-        var response = users.Select(ToProfile);
+        // Materialize to a List so XmlSerializer can serialize it (it can't serialize a lazy IEnumerable).
+        var response = users.Select(ToProfile).ToList();
         return Ok(response);
     }
 
@@ -269,6 +270,23 @@ public class UserController : ControllerBase
 }
 
 /// <summary>
-/// Summary DTO for vault information in user context.
+/// Summary DTO for vault information in user context. A class with a parameterless constructor so
+/// it is XML-serializable; the positional constructor keeps the EF projection working.
 /// </summary>
-public record VaultSummaryDto(int Id, string Name, string? Description, DateTime CreatedAt);
+public class VaultSummaryDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    public VaultSummaryDto() { }
+
+    public VaultSummaryDto(int id, string name, string? description, DateTime createdAt)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+        CreatedAt = createdAt;
+    }
+}

--- a/PassManAPI/DTOs/AuditDtos.cs
+++ b/PassManAPI/DTOs/AuditDtos.cs
@@ -65,7 +65,8 @@ public class AuditLogFilter
 /// </summary>
 public class PaginatedAuditResult
 {
-    public IEnumerable<AuditLogDto> Items { get; set; } = new List<AuditLogDto>();
+    // List (not IEnumerable): XmlSerializer can't serialize an interface-typed member.
+    public List<AuditLogDto> Items { get; set; } = new();
     public int TotalCount { get; set; }
     public int Page { get; set; }
     public int PageSize { get; set; }

--- a/PassManAPI/DTOs/CommonResponses.cs
+++ b/PassManAPI/DTOs/CommonResponses.cs
@@ -33,3 +33,20 @@ public record RoleAssignmentResponse
     public int UserId { get; init; }
     public string Role { get; init; } = string.Empty;
 }
+
+/// <summary>
+/// Generic message response (replaces anonymous <c>{ message }</c> bodies so they serialize as XML too).
+/// </summary>
+public class MessageResponse
+{
+    public string Message { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Response for accepting an invitation.
+/// </summary>
+public class InvitationAcceptedResponse
+{
+    public string Message { get; set; } = string.Empty;
+    public int VaultId { get; set; }
+}

--- a/PassManAPI/DTOs/CredentialDto.cs
+++ b/PassManAPI/DTOs/CredentialDto.cs
@@ -20,21 +20,22 @@ public class CredentialListItemDto
 /// <summary>
 /// Response DTO for Credential information.
 /// Note: Does not include the encrypted password for security reasons.
+/// A class with regular setters (not a positional record) so that XmlSerializer can deserialize it.
 /// </summary>
-public record CredentialDto
+public class CredentialDto
 {
-    public int Id { get; init; }
-    public string Title { get; init; } = string.Empty;
-    public string? Username { get; init; }
-    public string? Url { get; init; }
-    public string? Notes { get; init; }
-    public int? CategoryId { get; init; }
-    public string? CategoryName { get; init; }
-    public int VaultId { get; init; }
-    public DateTime CreatedAt { get; init; }
-    public DateTime? UpdatedAt { get; init; }
-    public DateTime? LastAccessed { get; init; }
-    public List<TagDto> Tags { get; init; } = new();
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string? Username { get; set; }
+    public string? Url { get; set; }
+    public string? Notes { get; set; }
+    public int? CategoryId { get; set; }
+    public string? CategoryName { get; set; }
+    public int VaultId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public DateTime? LastAccessed { get; set; }
+    public List<TagDto> Tags { get; set; } = new();
 }
 
 /// <summary>

--- a/PassManAPI/DTOs/CredentialDto.cs
+++ b/PassManAPI/DTOs/CredentialDto.cs
@@ -84,3 +84,28 @@ public record DecryptedPasswordDto
     public int CredentialId { get; init; }
     public string DecryptedPassword { get; init; } = string.Empty;
 }
+
+/// <summary>
+/// Response DTO for listing credentials in a vault (metadata only, no password).
+/// A class so it serializes as both JSON and XML (replaces the previous anonymous projection).
+/// </summary>
+public class CredentialListItemDto
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string? Username { get; set; }
+    public string? Url { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public DateTime? LastAccessed { get; set; }
+    public List<TagDto> Tags { get; set; } = new();
+}
+
+/// <summary>
+/// Response DTO carrying a credential's decrypted password (kept as a single <c>password</c> field
+/// for backward compatibility, now XML-serializable).
+/// </summary>
+public class PasswordResponse
+{
+    public string Password { get; set; } = string.Empty;
+}

--- a/PassManAPI/DTOs/TagDtos.cs
+++ b/PassManAPI/DTOs/TagDtos.cs
@@ -4,11 +4,22 @@ namespace PassManAPI.DTOs;
 
 /// <summary>
 /// Response DTO for Tag information.
+/// A class (not a positional record) with a parameterless constructor so it is XML-serializable
+/// by XmlSerializer; the (id, name) constructor keeps existing call sites and EF projections working.
 /// </summary>
-public record TagDto(
-    int Id,
-    string Name
-);
+public class TagDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+
+    public TagDto() { }
+
+    public TagDto(int id, string name)
+    {
+        Id = id;
+        Name = name;
+    }
+}
 
 /// <summary>
 /// Request DTO for creating a new tag.

--- a/PassManAPI/Managers/AuditManager.cs
+++ b/PassManAPI/Managers/AuditManager.cs
@@ -99,7 +99,7 @@ public class AuditManager : IAuditService
 
             return AuditOperationResult<PaginatedAuditResult>.Ok(new PaginatedAuditResult
             {
-                Items = items.Select(MapToDto),
+                Items = items.Select(MapToDto).ToList(),
                 TotalCount = totalCount,
                 Page = page,
                 PageSize = pageSize
@@ -158,7 +158,7 @@ public class AuditManager : IAuditService
 
             return AuditOperationResult<PaginatedAuditResult>.Ok(new PaginatedAuditResult
             {
-                Items = items.Select(MapToDto),
+                Items = items.Select(MapToDto).ToList(),
                 TotalCount = totalCount,
                 Page = page,
                 PageSize = pageSize
@@ -237,7 +237,7 @@ public class AuditManager : IAuditService
 
             return AuditOperationResult<PaginatedAuditResult>.Ok(new PaginatedAuditResult
             {
-                Items = items.Select(MapToDto),
+                Items = items.Select(MapToDto).ToList(),
                 TotalCount = totalCount,
                 Page = page,
                 PageSize = pageSize

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ dotnet test --filter "FullyQualifiedName~AuthEndpointsTests"
 - **[BACKUP_RECOVERY.md](/BACKUP_RECOVERY.md)** - Database backup procedures
 - **[ProjectSummary.md](/ProjectSummary.md)** - Feature breakdown and roadmap
 - **[GOOGLE_AUTH_DOCS.md](/GOOGLE_AUTH_DOCS.md)** - OAuth setup guide
+- **[docs/XML.md](docs/XML.md)** - How to send and receive XML (every endpoint supports JSON and XML)
 - **Swagger UI**: http://localhost:5246/swagger
 
 ## 🎯 Current Features

--- a/docs/XML.md
+++ b/docs/XML.md
@@ -1,0 +1,108 @@
+# Sending and Receiving XML
+
+The PassMan API speaks **both JSON and XML** on every endpoint. JSON is the default; XML is
+selected per-request via standard HTTP content negotiation. You never need a different URL — the
+same endpoints serve either format based on two headers:
+
+| Header | Purpose | Values |
+|--------|---------|--------|
+| `Accept` | Format you want **back** | `application/json` (default) or `application/xml` |
+| `Content-Type` | Format of the body you **send** | `application/json` or `application/xml` |
+
+The two are independent: you can POST XML and ask for a JSON response, or vice-versa.
+
+## Receiving XML (responses)
+
+Add `Accept: application/xml`:
+
+```bash
+curl http://localhost:5246/api/vaults \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/xml"
+```
+
+```xml
+<ArrayOfVaultResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ...>
+  <VaultResponse>
+    <Id>1</Id>
+    <Name>Personal</Name>
+    <IsOwner>true</IsOwner>
+  </VaultResponse>
+</ArrayOfVaultResponse>
+```
+
+Notes:
+- A collection serializes as `<ArrayOfXxx>` with one `<Xxx>` element per item.
+- **Element names are PascalCase** (the C# property names, e.g. `<AccessToken>`), whereas JSON uses
+  camelCase (`accessToken`). This is the XmlSerializer convention.
+- Without an `Accept` header (or with `*/*`), you get JSON.
+
+## Sending XML (request bodies)
+
+Set `Content-Type: application/xml` and send the element shape matching the request DTO. Example —
+log in with an XML body and get an XML response:
+
+```bash
+curl -X POST http://localhost:5246/api/auth/login \
+  -H "Content-Type: application/xml" \
+  -H "Accept: application/xml" \
+  --data '<LoginRequest><Email>user@example.com</Email><Password>Passw0rd!</Password></LoginRequest>'
+```
+
+Create a credential from XML:
+
+```bash
+curl -X POST http://localhost:5246/api/vaults/1/credentials \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/xml" \
+  --data '<CreateCredentialRequest>
+            <Title>GitHub</Title>
+            <Username>octocat</Username>
+            <EncryptedPassword>s3cret</EncryptedPassword>
+            <Url>https://github.com</Url>
+          </CreateCredentialRequest>'
+```
+
+The root element name is the request type (`LoginRequest`, `CreateCredentialRequest`, `RegisterRequest`,
+`CreateVaultRequest`, `CreateTagRequest`, `CreateInvitationRequest`, …); child elements are the
+PascalCase property names.
+
+## Errors in XML
+
+> Error-body content negotiation (4xx/5xx in XML) is delivered by the error-handling change in
+> **#178** (PR #183). The examples below describe the behaviour once that is merged to `develop`.
+
+Error bodies content-negotiate the same way — request `Accept: application/xml` and a 4xx/5xx comes
+back as XML instead of JSON:
+
+```xml
+<ErrorResponse xmlns:xsi="...">
+  <Type>https://tools.ietf.org/html/rfc7231#section-6.5.4</Type>
+  <Title>Not Found</Title>
+  <Status>404</Status>
+  <Detail>Vault not found.</Detail>
+  <TraceId>00-...-00</TraceId>
+</ErrorResponse>
+```
+
+Validation (400) errors include the field errors as a `<errors>` list:
+
+```xml
+<ErrorResponse>
+  <Title>One or more validation errors occurred.</Title>
+  <Status>400</Status>
+  <errors>
+    <error field="Email"><message>The Email field is required.</message></error>
+  </errors>
+</ErrorResponse>
+```
+
+## How it's wired (for maintainers)
+
+- `Program.cs` registers `AddXmlSerializerFormatters()`, enabling the `XmlSerializer` input/output
+  formatters alongside the JSON ones.
+- Response DTOs are **classes or nominal records with a parameterless constructor** — `XmlSerializer`
+  cannot serialize positional records (no parameterless ctor) or anonymous types, and cannot serialize
+  interface-typed members (e.g. `IEnumerable<T>`), so list endpoints return concrete `List<T>`.
+- Pipeline errors (the global exception handler and the 401/403 auth-pipeline responses) are written
+  by `ErrorResponseWriter`, which negotiates XML/JSON from the `Accept` header outside MVC.

--- a/docs/XML.md
+++ b/docs/XML.md
@@ -88,9 +88,11 @@ back as XML instead of JSON:
 Validation (400) errors include the field errors as a `<errors>` list:
 
 ```xml
-<ErrorResponse>
+<ErrorResponse xmlns:xsi="...">
+  <Type>https://tools.ietf.org/html/rfc7231#section-6.5.1</Type>
   <Title>One or more validation errors occurred.</Title>
   <Status>400</Status>
+  <TraceId>00-...</TraceId>
   <errors>
     <error field="Email"><message>The Email field is required.</message></error>
   </errors>
@@ -106,3 +108,5 @@ Validation (400) errors include the field errors as a `<errors>` list:
   interface-typed members (e.g. `IEnumerable<T>`), so list endpoints return concrete `List<T>`.
 - Pipeline errors (the global exception handler and the 401/403 auth-pipeline responses) are written
   by `ErrorResponseWriter`, which negotiates XML/JSON from the `Accept` header outside MVC.
+- The user-management controller maps to **`/api/user`** (singular — follows `[controller]` from
+  `UserController`), not `/api/users`. All other controllers use plurals (`/api/vaults`, `/api/tags`, …).

--- a/scripts/PASSMAN-tests.postman_collection.json
+++ b/scripts/PASSMAN-tests.postman_collection.json
@@ -1,5619 +1,6051 @@
-{
-  "info": {
-    "_postman_id": "e2c97322-c45f-483f-b90d-f0c8b32a2fd3",
-    "name": "PassManAPI - Full Endpoint Coverage Copy 9",
-    "description": "Comprehensive collection: positive and negative tests for Auth (expanded), Vaults, Credentials, Tags, Invitations, Audit. Run against Docker-local API at {{baseUrl}}.",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "53985542",
-    "_collection_link": "https://go.postman.co/collection/53985542-e2c97322-c45f-483f-b90d-f0c8b32a2fd3?source=collection_link"
-  },
-  "event": [
-    {
-      "listen": "test",
-      "script": {
-        "type": "text/javascript",
-        "exec": [
-          "var code = pm.response.code;",
-          "var contentType = (pm.response.headers.get('Content-Type') || '').toLowerCase();",
-          "var rawText = pm.response.text() || '';",
-          "var textLower = rawText.toLowerCase();",
-          "var requestUrl = pm.request && pm.request.url ? pm.request.url.toString() : '';",
-          "function safeJson(){ try { return pm.response.json(); } catch (e) { return null; } }",
-          "function hasStructuredError(obj){ return !!obj && typeof obj === 'object' && (obj.error !== undefined || obj.message !== undefined || obj.title !== undefined || obj.detail !== undefined || obj.errors !== undefined); }",
-          "function expectStructuredErrorResponse(label){",
-          "  pm.test(label + ' has a non-empty error body', function(){",
-          "    pm.expect(rawText.length).to.be.greaterThan(0);",
-          "  });",
-          "  pm.test(label + ' is structured JSON', function(){",
-          "    var body = safeJson();",
-          "    pm.expect(body).to.not.eql(null);",
-          "    pm.expect(hasStructuredError(body)).to.eql(true);",
-          "  });",
-          "}",
-          "if (code >= 400) {",
-          "  pm.test('hardening: error response is not html', function(){",
-          "    pm.expect(contentType.indexOf('text/html')).to.eql(-1);",
-          "    pm.expect(textLower.indexOf('<html')).to.eql(-1);",
-          "  });",
-          "}",
-          "if (contentType.indexOf('application/json') !== -1 || contentType.indexOf('application/problem+json') !== -1) {",
-          "  pm.test('hardening: json responses are parseable', function(){",
-          "    pm.expect(safeJson()).to.not.eql(null);",
-          "  });",
-          "}",
-          "if (code >= 500) {",
-          "  pm.test('hardening: no unhandled server errors', function(){",
-          "    pm.expect.fail('Unexpected 5xx response ' + code + ' for ' + requestUrl + ' body=' + rawText);",
-          "  });",
-          "}",
-          "if (code === 204) {",
-          "  pm.test('hardening: 204 response body is empty', function(){",
-          "    pm.expect(rawText.length).to.eql(0);",
-          "  });",
-          "}",
-          "if ((code === 200 || code === 201) && (contentType.indexOf('application/json') !== -1 || contentType.indexOf('application/problem+json') !== -1)) {",
-          "  pm.test('hardening: successful json responses are parseable', function(){",
-          "    pm.expect(safeJson()).to.not.eql(null);",
-          "  });",
-          "}",
-          "if (code === 400) {",
-          "  pm.test('hardening: 400 has non-empty payload', function(){",
-          "    pm.expect(rawText.length).to.be.greaterThan(0);",
-          "  });",
-          "  pm.test('hardening: 400 payload schema is valid', function(){",
-          "    var body = safeJson();",
-          "    if (contentType.indexOf('application/problem+json') !== -1) {",
-          "      pm.expect(body).to.be.an('object');",
-          "      pm.expect(body).to.have.property('title');",
-          "      pm.expect(body).to.have.property('status');",
-          "      pm.expect(body.status).to.eql(400);",
-          "      pm.expect(body).to.have.property('errors');",
-          "      pm.expect(body.errors).to.be.an('object');",
-          "    } else if (contentType.indexOf('application/json') !== -1 && body !== null) {",
-          "      if (typeof body === 'string') {",
-          "        pm.expect(body.length).to.be.greaterThan(0);",
-          "      } else {",
-          "        pm.expect(body).to.be.an('object');",
-          "        pm.expect(Object.keys(body).length).to.be.greaterThan(0);",
-          "        pm.expect(hasStructuredError(body)).to.eql(true);",
-          "      }",
-          "    }",
-          "  });",
-          "}",
-          "if (code === 404) {",
-          "  pm.test('hardening: 404 payload schema when body is present', function(){",
-          "    expectStructuredErrorResponse('404');",
-          "  });",
-          "}",
-          "if (code === 401 || code === 403) {",
-          "  pm.test('hardening: 401/403 body schema when present', function(){",
-          "    expectStructuredErrorResponse(code.toString());",
-          "  });",
-          "}",
-          "if (code === 404 && requestUrl.indexOf('/api/audit/logs') !== -1) {",
-          "  pm.test('hardening: audit 404 has structured error body when present', function(){",
-          "    if (rawText.length === 0) { return; }",
-          "    var body = safeJson();",
-          "    if (body && typeof body === 'object') {",
-          "      pm.expect(hasStructuredError(body)).to.eql(true);",
-          "    }",
-          "  });",
-          "}",
-          "if (code === 400 && requestUrl.indexOf('/api/audit/') !== -1) {",
-          "  pm.test('hardening: audit 400 has structured error body', function(){",
-          "    var body = safeJson();",
-          "    if (body && typeof body === 'object') {",
-          "      pm.expect(hasStructuredError(body)).to.eql(true);",
-          "    }",
-          "  });",
-          "}",
-          "if (requestUrl.indexOf('/api/auth/login') !== -1 && code === 401) {",
-          "  pm.test('hardening: auth login 401 message contract', function(){",
-          "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf('invalid credentials') !== -1 || x.indexOf('email not confirmed') !== -1; });",
-          "  });",
-          "}",
-          "if (requestUrl.indexOf('/api/auth/login') !== -1 && code === 423) {",
-          "  pm.test('hardening: auth login 423 message contract', function(){",
-          "    pm.expect(textLower).to.include('account is locked');",
-          "  });",
-          "}",
-          "if (requestUrl.indexOf('/api/auth/google') !== -1 && code === 400) {",
-          "  pm.test('hardening: google login 400 message contract', function(){",
-          "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf('invalid google token') !== -1 || x.indexOf('google login failed') !== -1; });",
-          "  });",
-          "}",
-          "if (requestUrl.indexOf('/api/vaults/') !== -1 && requestUrl.indexOf('/share') !== -1 && code === 404) {",
-          "  pm.test('hardening: vault share 404 message contract when body exists', function(){",
-          "    if (rawText.length === 0) { return; }",
-          "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf('vault not found') !== -1 || x.indexOf('target user not found') !== -1 || x.indexOf('share not found') !== -1; });",
-          "  });",
-          "}",
-          "if (requestUrl.indexOf('/api/invitations') !== -1 && (code === 400 || code === 404)) {",
-          "  pm.test('hardening: invitation error message contract', function(){",
-          "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf('invitation') !== -1 || x.indexOf('vault not found') !== -1 || x.indexOf('invalid role') !== -1 || x.indexOf('different email address') !== -1 || x.indexOf('not found') !== -1 || x.indexOf('permission') !== -1; });",
-          "  });",
-          "}"
-        ]
-      }
-    }
-  ],
-  "item": [
-    {
-      "name": "Auth",
-      "item": [
-        {
-          "name": "Auth - Register (201)",
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "exec": [
-                  "pm.environment.set('timestamp', Date.now());",
-                  "pm.environment.set('userEmail', 'smoke+' + pm.environment.get('timestamp') + '@test.local');"
-                ],
-                "type": "text/javascript"
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
-                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.user) pm.environment.set('userId', r.user.id || r.user.Id || ''); if(r && r.accessToken) pm.environment.set('accessToken', r.accessToken || r.AccessToken || ''); }catch(e){} }"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"email\": \"smoke+{{timestamp}}@test.local\",\n  \"password\": \"{{userPassword}}\",\n  \"confirmPassword\": \"{{userPassword}}\",\n  \"userName\": \"smokeuser{{timestamp}}\"\n}"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/register",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "register"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Register Missing Email (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
-                  "pm.test('contains email', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('email'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"password\": \"Password1!\", \"confirmPassword\": \"Password1!\", \"userName\": \"x\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/register",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "register"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Register Password Mismatch (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
-                  "pm.test('contains password mismatch/validation message', function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes('password') || x.includes('confirm') || x.includes('match') || x.includes('validation'); }); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"badpw+{{timestamp}}@test.local\", \"password\": \"Password1!\", \"confirmPassword\": \"Different1!\", \"userName\": \"x\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/register",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "register"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Login (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
-                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.accessToken) pm.environment.set('accessToken', r.accessToken || r.AccessToken || ''); if(r && r.user) pm.environment.set('userId', r.user.id || r.user.Id || ''); }catch(e){} }"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"{{userEmail}}\", \"password\": \"{{userPassword}}\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/login",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "login"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Login Missing Fields (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/login",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "login"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Login Invalid Credentials (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });",
-                  "pm.test('contains invalid credentials message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('invalid credentials'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"no-such-user@test.local\", \"password\": \"wrong\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/login",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "login"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Login Locked (423)",
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "exec": [
-                  "var baseUrl = pm.variables.get('baseUrl');",
-                  "var email = pm.variables.get('userEmail');",
-                  "var wrongPassword = 'WrongLockout123!';",
-                  "for (var i = 0; i < 5; i++) {",
-                  "  pm.sendRequest({",
-                  "    url: baseUrl + '/api/auth/login',",
-                  "    method: 'POST',",
-                  "    header: { 'Content-Type': 'application/json' },",
-                  "    body: { mode: 'raw', raw: JSON.stringify({ email: email, password: wrongPassword }) }",
-                  "  }, function () {});",
-                  "}"
-                ],
-                "type": "text/javascript"
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 or 423 while lockout state settles', function(){ pm.expect([401,423]).to.include(pm.response.code); });",
-                  "pm.test('contains invalid credentials or account locked message', function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes('invalid credentials') || x.includes('account is locked'); }); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"{{userEmail}}\", \"password\": \"wrong1\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/login",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "login"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Google Invalid Token (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
-                  "pm.test('contains google token error message', function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes('invalid google token') || x.includes('google login failed'); }); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"idToken\": \"invalid-token\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/google",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "google"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Me Get Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/me",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "me"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Me Get (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/me",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "me"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Update Profile Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"userName\": \"x\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/me",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "me"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Update Profile BadRequest (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
-                  "pm.test('contains email validation', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('email'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"not-an-email\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/me",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "me"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Update Profile (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"userName\": \"updated-{{timestamp}}\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/me",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "me"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Delete Account Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/me",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "me"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Delete Account NotFound (404)",
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "exec": [
-                  "var baseUrl = pm.variables.get('baseUrl');",
-                  "var ts = Date.now();",
-                  "var email = 'deleted+' + ts + '@test.local';",
-                  "var password = pm.variables.get('userPassword') || 'Password1!';",
-                  "var registerPayload = { email: email, password: password, confirmPassword: password, userName: 'deleted' + ts };",
-                  "pm.sendRequest({",
-                  "  url: baseUrl + '/api/auth/register',",
-                  "  method: 'POST',",
-                  "  header: { 'Content-Type': 'application/json' },",
-                  "  body: { mode: 'raw', raw: JSON.stringify(registerPayload) }",
-                  "}, function (err, res) {",
-                  "  if (err || !res || res.code !== 201) { return; }",
-                  "  var body = {};",
-                  "  try { body = res.json(); } catch (e) {}",
-                  "  var token = body.accessToken || '';",
-                  "  if (!token) { return; }",
-                  "  pm.environment.set('deletedAccessToken', token);",
-                  "  pm.sendRequest({",
-                  "    url: baseUrl + '/api/auth/me',",
-                  "    method: 'DELETE',",
-                  "    header: { Authorization: 'Bearer ' + token }",
-                  "  }, function () {});",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains user not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('user not found'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{deletedAccessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/me",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "me"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Permissions Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/permissions",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "permissions"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Permissions (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/permissions",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "permissions"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Assign Role Forbidden (403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
-                  "pm.test('forbidden/unauthorized message present', function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } else { pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('unauthorized') || x.length === 0; }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              },
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"userId\": 999999, \"role\": \"Admin\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/assign-role",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "assign-role"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Assign Role BadRequest (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
-                  "pm.test('contains role does not exist message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('does not exist'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{adminUserId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"userId\": {{userId}}, \"role\": \"NonExistentRole\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/assign-role",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "assign-role"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Assign Role NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains user not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('user not found'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{adminUserId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"userId\": 999999, \"role\": \"Admin\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/assign-role",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "assign-role"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Assign Role (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{adminUserId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"userId\": {{userId}}, \"role\": \"VaultOwner\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/assign-role",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "assign-role"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Auth - Assign Role Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer invalid_token"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"userId\": {{userId}}, \"role\": \"User\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/auth/assign-role",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "auth",
-                "assign-role"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Users",
-      "item": [
-        {
-          "name": "Users - List Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/user",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - List Forbidden (403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
-                  "pm.test('if 403 then forbidden message', function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - List (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
-                  "pm.test('if 403 then forbidden message', function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{adminUserId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/{{userId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "{{userId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get Forbidden/NotFound (403|404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
-                  "pm.test('contains expected get-user error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('user not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
-                  "pm.test('contains forbidden message when present', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('permission'); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/{{userId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "{{userId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Update Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"x\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/user/{{userId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "{{userId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Update BadRequest (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"not-an-email\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/user/{{userId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "{{userId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Update Forbidden/NotFound (403|404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
-                  "pm.test('contains expected update-user error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('user not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"x@test.local\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/user/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Update (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
-                  "pm.environment.set('userEmail', 'updated+' + pm.environment.get('timestamp') + '@test.local');"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"updated+{{timestamp}}@test.local\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/user/{{userId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "{{userId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Delete Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/{{userId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "{{userId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Delete Forbidden/NotFound (403|404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
-                  "pm.test('contains expected delete-user error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('user not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get Vaults Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/{{userId}}/vaults",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "{{userId}}",
-                "vaults"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get Vaults Forbidden/NotFound (403|404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
-                  "pm.test('contains expected get-vaults error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('user not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/999999/vaults",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "999999",
-                "vaults"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get Vaults Forbidden (403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
-                  "pm.test('contains forbidden message when present', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('permission'); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/999999/vaults",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "999999",
-                "vaults"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get Vaults (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/{{userId}}/vaults",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "{{userId}}",
-                "vaults"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get Tags Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/{{userId}}/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "{{userId}}",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get Tags Forbidden/NotFound (403|404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
-                  "pm.test('contains expected get-tags error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('user not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/999999/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "999999",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get Tags Forbidden (403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/999999/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "999999",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Users - Get Tags (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/user/{{userId}}/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "user",
-                "{{userId}}",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Vaults",
-      "item": [
-        {
-          "name": "Vaults - Create Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"noauth\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Vaults - Create BadRequest (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
-                  "pm.test('contains validation details', function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes('validation') || x.includes('errors') || x.includes('required') || x.includes('invalid or unauthorized tag ids'); }); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Vaults - Create (201)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
-                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('vaultId', r.id); }catch(e){} }"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"Smoke Vault {{timestamp}}\", \"userId\": {{userId}} }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Vaults - List (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Vaults - Get (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Vaults - Update (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"Updated Vault {{timestamp}}\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Vaults - Create For Deletion (201)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
-                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('deleteVaultId', r.id); }catch(e){} }"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"TempDeleteVault {{timestamp}}\", \"userId\": {{userId}} }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Vaults - Delete (204)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{deleteVaultId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{deleteVaultId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Vaults - Delete NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains vault not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('vault not found'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/999998",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "999998"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Credentials",
-      "item": [
-        {
-          "name": "Credentials - List Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/1/credentials",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "1",
-                "credentials"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - List Forbidden/NotFound (403|404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 or 404 (vault does not belong to user or does not exist)', function(){ pm.expect(pm.response.code).to.be.oneOf([403, 404]); });",
-                  "pm.test('contains expected list-credentials error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 403){ pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('not found') || x.length === 0; }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/999999/credentials",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "999999",
-                "credentials"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - List (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "credentials"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Create Missing Password (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"title\": \"NoPass\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "credentials"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Create NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains vault not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('vault not found'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"title\": \"NoPerm\", \"encryptedPassword\": \"x\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/999999/credentials",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "999999",
-                "credentials"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Create (201)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
-                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('credentialId', r.id); }catch(e){} }"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"title\": \"Smoke Credential {{timestamp}}\", \"encryptedPassword\": \"s3cret\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "credentials"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Get Password Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/1/password",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "1",
-                "password"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Get Password NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/999999/password",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "999999",
-                "password"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Get Password Forbidden/NotFound (403|404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/password",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}",
-                "password"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Get Password (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
-                  "pm.test('has password', function(){ try{ var j = JSON.parse(pm.response.text()); pm.expect(j).to.have.property('password'); }catch(e){ pm.expect.fail('response not json or empty'); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/password",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}",
-                "password"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Update Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"title\": \"x\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/1",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "1"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Update NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"title\": \"x\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Update Forbidden (403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"title\": \"x\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Update BadRequest (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Update (204)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"title\": \"Updated Title {{timestamp}}\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Update Password BadRequest (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/password",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}",
-                "password"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Update Password (204)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"encryptedPassword\": \"newpass\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/password",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}",
-                "password"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Delete Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/1",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "1"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Delete NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Delete NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains credential not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('credential not found'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/999998",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "999998"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Create For Deletion (201)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
-                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('deleteCredentialId', r.id); }catch(e){} }"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"title\": \"TempDeleteCred {{timestamp}}\", \"encryptedPassword\": \"s3cret\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "credentials"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Delete (204)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{deleteCredentialId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{deleteCredentialId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Get Tags Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/1/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "1",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Get Tags NotFound/Forbidden (404|403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains expected get-tags error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.satisfy(function(x){ return x.includes('credential not found') || x.includes('not found'); }); } else { pm.expect(t).to.include('permission'); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/999997/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "999997",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Get Tags (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Setup Create Tag (201)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
-                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('credTagId', r.id); }catch(e){} }"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"cred-tag-{{timestamp}}\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Set Tags BadRequest (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"tagIds\": [999999] }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Set Tags (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
-                  "pm.test('returns array of tags', function(){ pm.expect(pm.response.json()).to.be.an('array'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"tagIds\": [{{credTagId}}] }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Add Tag BadRequest/NotFound (400|404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains expected add-tag error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.satisfy(function(x){ return x.includes('tag not found') || x.includes('credential not found'); }); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('tag does not belong') || x.includes('already assigned'); }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}",
-                "tags",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Setup Create Second Tag (201)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
-                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('credTagId2', r.id); }catch(e){} }"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"cred-tag2-{{timestamp}}\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Add Tag (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });",
-                  "pm.test('returns tag added message', function(){ var b = pm.response.json(); pm.expect(b).to.have.property('message'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags/{{credTagId2}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}",
-                "tags",
-                "{{credTagId2}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Remove Tag NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains tag assignment not found message', function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes('not assigned to this credential') || x.includes('credential not found'); }); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}",
-                "tags",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Remove Tag CredentialNotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains credential not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('credential not found'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/999999/tags/1",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "999999",
-                "tags",
-                "1"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Credentials - Remove Tag (204)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/credentials/{{credentialId}}/tags/{{credTagId2}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "credentials",
-                "{{credentialId}}",
-                "tags",
-                "{{credTagId2}}"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Tags",
-      "item": [
-        {
-          "name": "Tags - List Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - List (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Get Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/tags/{{tagId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags",
-                "{{tagId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Get NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains not found message when present', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('not found'); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/tags/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Get (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/tags/{{tagId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags",
-                "{{tagId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Create Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"noauth\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Create BadRequest (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Create (201)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
-                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('tagId', r.id); }catch(e){} }"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"smoke-tag-{{timestamp}}\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Create Duplicate (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
-                  "pm.test('contains duplicate tag message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('already exists'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"smoke-tag-{{timestamp}}\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Update Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"x\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/tags/1",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags",
-                "1"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Update NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"x\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/tags/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Setup Create Conflict Tag",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "// 201 on first run, 400 if tag already exists — both are fine"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"existing-name\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/tags",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Update Forbidden or BadRequest (403|400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
-                  "pm.test('contains duplicate tag message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('already exists'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"existing-name\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/tags/{{tagId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags",
-                "{{tagId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Update (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"name\": \"renamed-{{timestamp}}\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/tags/{{tagId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags",
-                "{{tagId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Delete Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/tags/1",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags",
-                "1"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Delete NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/tags/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Delete Forbidden (403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/tags/999998",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags",
-                "999998"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Tags - Delete (204)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/tags/{{tagId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "tags",
-                "{{tagId}}"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Invitations",
-      "item": [
-        {
-          "name": "Invitations - Create Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"invitee@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"View\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Create VaultNotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"invitee@test.local\", \"vaultId\": 999999, \"role\": \"View\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Create Forbid (403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"invitee@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"View\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Create BadRequest (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"invitee+{{timestamp}}@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"NotARole\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Create (201)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('201 Created', function(){ pm.response.to.have.status(201); });",
-                  "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r && r.id) pm.environment.set('invitationId', r.id); if(r && r.inviteToken) pm.environment.set('inviteToken', r.inviteToken); }catch(e){} }"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"email\": \"invitee+{{timestamp}}@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"View\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - List Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - List (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Accept Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations/invalid_token/accept",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations",
-                "invalid_token",
-                "accept"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Accept NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations/no-such-token/accept",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations",
-                "no-such-token",
-                "accept"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Accept BadRequest (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });",
-                  "pm.test('contains invitation mismatch/not found message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('invitation not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('different email address') || x.includes('cannot'); }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations/{{inviteToken}}/accept",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations",
-                "{{inviteToken}}",
-                "accept"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Accept (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('400 BadRequest', function(){ pm.response.to.have.status(400); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations/{{inviteToken}}/accept",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations",
-                "{{inviteToken}}",
-                "accept"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Revoke Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations/1",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations",
-                "1"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Revoke NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains not found message when present', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('not found'); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Revoke Forbidden (403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations/999998",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations",
-                "999998"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Invitations - Revoke (204)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/invitations/{{invitationId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "invitations",
-                "{{invitationId}}"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "VaultShares",
-      "item": [
-        {
-          "name": "VaultShares - Share Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"userEmail\": \"noone@test.local\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "share"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "VaultShares - Share BadRequest (400)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "share"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "VaultShares - Share NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"userEmail\": \"noone@test.local\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/999999/share",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "999999",
-                "share"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "VaultShares - Share Forbidden (403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"userEmail\": \"noone@test.local\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "share"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "VaultShares - Share (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('404 contains target user not found message', function(){ if(pm.response.code === 404){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('target user not found') || x.includes('vault not found'); }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{ \"userEmail\": \"invitee+{{timestamp}}@test.local\" }"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "share"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "VaultShares - Revoke Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share/{{userId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "share",
-                "{{userId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "VaultShares - Revoke NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains share not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('share not found') || x.includes('vault not found'); }); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "share",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "VaultShares - Revoke Forbidden (403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share/{{userId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "share",
-                "{{userId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "VaultShares - Revoke (204)",
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "exec": [
-                  "var baseUrl = pm.variables.get('baseUrl');",
-                  "var vaultId = pm.variables.get('vaultId');",
-                  "var ownerEmail = pm.variables.get('userEmail');",
-                  "var ownerId = pm.variables.get('userId');",
-                  "pm.sendRequest({",
-                  "  url: baseUrl + '/api/vaults/' + vaultId + '/share',",
-                  "  method: 'POST',",
-                  "  header: { 'Content-Type': 'application/json', 'X-UserId': String(ownerId) },",
-                  "  body: { mode: 'raw', raw: JSON.stringify({ userEmail: ownerEmail }) }",
-                  "}, function () {});"
-                ],
-                "type": "text/javascript"
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('204 NoContent', function(){ pm.response.to.have.status(204); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/vaults/{{vaultId}}/share/{{userId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "vaults",
-                "{{vaultId}}",
-                "share",
-                "{{userId}}"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Audit",
-      "item": [
-        {
-          "name": "Audit - Get My Logs Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Audit - Get My Logs (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Audit - Get Log By Id Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs/1",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs",
-                "1"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Audit - Get Log By Id Forbidden/NotFound (403|404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 or 404 (log belongs to another user or does not exist)', function(){ pm.expect(pm.response.code).to.be.oneOf([403, 404]); });",
-                  "pm.test('contains expected get-log-by-id error message', function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include('audit log not found'); } else { pm.expect(t).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Audit - Get Log By Id NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains audit log not found error message', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('audit log not found'); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Audit - Get Vault Logs Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs/vault/{{vaultId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs",
-                "vault",
-                "{{vaultId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Audit - Get Vault Logs NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains vault not found message', function(){ pm.expect(pm.response.text().toLowerCase()).to.include('vault not found'); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs/vault/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs",
-                "vault",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Audit - Get Vault Logs NotFound (404)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('404 NotFound', function(){ pm.response.to.have.status(404); });",
-                  "pm.test('contains vault not found error message', function(){ var t = pm.response.text().toLowerCase(); if(t.length > 0){ pm.expect(t).to.include('vault not found'); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs/vault/999999",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs",
-                "vault",
-                "999999"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Audit - Get Vault Logs (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs/vault/{{vaultId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs",
-                "vault",
-                "{{vaultId}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Audit - Get All Logs Unauthorized (401)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('401 Unauthorized', function(){ pm.response.to.have.status(401); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs/all",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs",
-                "all"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Audit - Get All Logs (200)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('200 OK', function(){ pm.response.to.have.status(200); });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{adminUserId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs/all",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs",
-                "all"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Audit - Get All Logs Forbidden (403)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('403 Forbidden', function(){ pm.response.to.have.status(403); });",
-                  "pm.test('if 403 then forbidden message', function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes('forbid') || x.includes('forbidden') || x.length === 0; }); } });"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "X-UserId",
-                "value": "{{userId}}"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/api/audit/logs/all",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "audit",
-                "logs",
-                "all"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    }
-  ],
-  "variable": [
-    {
-      "key": "baseUrl",
-      "value": "http://localhost:5246"
-    },
-    {
-      "key": "timestamp",
-      "value": ""
-    },
-    {
-      "key": "userEmail",
-      "value": ""
-    },
-    {
-      "key": "userPassword",
-      "value": "Password1!"
-    },
-    {
-      "key": "userId",
-      "value": ""
-    },
-    {
-      "key": "accessToken",
-      "value": ""
-    },
-    {
-      "key": "adminUserId",
-      "value": "1"
-    },
-    {
-      "key": "vaultId",
-      "value": ""
-    },
-    {
-      "key": "credentialId",
-      "value": ""
-    },
-    {
-      "key": "tagId",
-      "value": ""
-    },
-    {
-      "key": "invitationId",
-      "value": ""
-    }
-  ]
+﻿{
+    "info":  {
+                 "_postman_id":  "e2c97322-c45f-483f-b90d-f0c8b32a2fd3",
+                 "name":  "PassManAPI - Full Endpoint Coverage Copy 9",
+                 "description":  "Comprehensive collection: positive and negative tests for Auth (expanded), Vaults, Credentials, Tags, Invitations, Audit. Run against Docker-local API at {{baseUrl}}.",
+                 "schema":  "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+                 "_exporter_id":  "53985542",
+                 "_collection_link":  "https://go.postman.co/collection/53985542-e2c97322-c45f-483f-b90d-f0c8b32a2fd3?source=collection_link"
+             },
+    "event":  [
+                  {
+                      "listen":  "test",
+                      "script":  {
+                                     "type":  "text/javascript",
+                                     "exec":  [
+                                                  "var code = pm.response.code;",
+                                                  "var contentType = (pm.response.headers.get(\u0027Content-Type\u0027) || \u0027\u0027).toLowerCase();",
+                                                  "var rawText = pm.response.text() || \u0027\u0027;",
+                                                  "var textLower = rawText.toLowerCase();",
+                                                  "var requestUrl = pm.request \u0026\u0026 pm.request.url ? pm.request.url.toString() : \u0027\u0027;",
+                                                  "function safeJson(){ try { return pm.response.json(); } catch (e) { return null; } }",
+                                                  "function hasStructuredError(obj){ return !!obj \u0026\u0026 typeof obj === \u0027object\u0027 \u0026\u0026 (obj.error !== undefined || obj.message !== undefined || obj.title !== undefined || obj.detail !== undefined || obj.errors !== undefined); }",
+                                                  "function expectStructuredErrorResponse(label){",
+                                                  "  pm.test(label + \u0027 has a non-empty error body\u0027, function(){",
+                                                  "    pm.expect(rawText.length).to.be.greaterThan(0);",
+                                                  "  });",
+                                                  "  pm.test(label + \u0027 is structured JSON\u0027, function(){",
+                                                  "    var body = safeJson();",
+                                                  "    pm.expect(body).to.not.eql(null);",
+                                                  "    pm.expect(hasStructuredError(body)).to.eql(true);",
+                                                  "  });",
+                                                  "}",
+                                                  "if (code \u003e= 400) {",
+                                                  "  pm.test(\u0027hardening: error response is not html\u0027, function(){",
+                                                  "    pm.expect(contentType.indexOf(\u0027text/html\u0027)).to.eql(-1);",
+                                                  "    pm.expect(textLower.indexOf(\u0027\u003chtml\u0027)).to.eql(-1);",
+                                                  "  });",
+                                                  "}",
+                                                  "if (contentType.indexOf(\u0027application/json\u0027) !== -1 || contentType.indexOf(\u0027application/problem+json\u0027) !== -1) {",
+                                                  "  pm.test(\u0027hardening: json responses are parseable\u0027, function(){",
+                                                  "    pm.expect(safeJson()).to.not.eql(null);",
+                                                  "  });",
+                                                  "}",
+                                                  "if (code \u003e= 500) {",
+                                                  "  pm.test(\u0027hardening: no unhandled server errors\u0027, function(){",
+                                                  "    pm.expect.fail(\u0027Unexpected 5xx response \u0027 + code + \u0027 for \u0027 + requestUrl + \u0027 body=\u0027 + rawText);",
+                                                  "  });",
+                                                  "}",
+                                                  "if (code === 204) {",
+                                                  "  pm.test(\u0027hardening: 204 response body is empty\u0027, function(){",
+                                                  "    pm.expect(rawText.length).to.eql(0);",
+                                                  "  });",
+                                                  "}",
+                                                  "if ((code === 200 || code === 201) \u0026\u0026 (contentType.indexOf(\u0027application/json\u0027) !== -1 || contentType.indexOf(\u0027application/problem+json\u0027) !== -1)) {",
+                                                  "  pm.test(\u0027hardening: successful json responses are parseable\u0027, function(){",
+                                                  "    pm.expect(safeJson()).to.not.eql(null);",
+                                                  "  });",
+                                                  "}",
+                                                  "if (code === 400) {",
+                                                  "  pm.test(\u0027hardening: 400 has non-empty payload\u0027, function(){",
+                                                  "    pm.expect(rawText.length).to.be.greaterThan(0);",
+                                                  "  });",
+                                                  "  pm.test(\u0027hardening: 400 payload schema is valid\u0027, function(){",
+                                                  "    var body = safeJson();",
+                                                  "    if (contentType.indexOf(\u0027application/problem+json\u0027) !== -1) {",
+                                                  "      pm.expect(body).to.be.an(\u0027object\u0027);",
+                                                  "      pm.expect(body).to.have.property(\u0027title\u0027);",
+                                                  "      pm.expect(body).to.have.property(\u0027status\u0027);",
+                                                  "      pm.expect(body.status).to.eql(400);",
+                                                  "      pm.expect(body).to.have.property(\u0027errors\u0027);",
+                                                  "      pm.expect(body.errors).to.be.an(\u0027object\u0027);",
+                                                  "    } else if (contentType.indexOf(\u0027application/json\u0027) !== -1 \u0026\u0026 body !== null) {",
+                                                  "      if (typeof body === \u0027string\u0027) {",
+                                                  "        pm.expect(body.length).to.be.greaterThan(0);",
+                                                  "      } else {",
+                                                  "        pm.expect(body).to.be.an(\u0027object\u0027);",
+                                                  "        pm.expect(Object.keys(body).length).to.be.greaterThan(0);",
+                                                  "        pm.expect(hasStructuredError(body)).to.eql(true);",
+                                                  "      }",
+                                                  "    }",
+                                                  "  });",
+                                                  "}",
+                                                  "if (code === 404) {",
+                                                  "  pm.test(\u0027hardening: 404 payload schema when body is present\u0027, function(){",
+                                                  "    expectStructuredErrorResponse(\u0027404\u0027);",
+                                                  "  });",
+                                                  "}",
+                                                  "if (code === 401 || code === 403) {",
+                                                  "  pm.test(\u0027hardening: 401/403 body schema when present\u0027, function(){",
+                                                  "    expectStructuredErrorResponse(code.toString());",
+                                                  "  });",
+                                                  "}",
+                                                  "if (code === 404 \u0026\u0026 requestUrl.indexOf(\u0027/api/audit/logs\u0027) !== -1) {",
+                                                  "  pm.test(\u0027hardening: audit 404 has structured error body when present\u0027, function(){",
+                                                  "    if (rawText.length === 0) { return; }",
+                                                  "    var body = safeJson();",
+                                                  "    if (body \u0026\u0026 typeof body === \u0027object\u0027) {",
+                                                  "      pm.expect(hasStructuredError(body)).to.eql(true);",
+                                                  "    }",
+                                                  "  });",
+                                                  "}",
+                                                  "if (code === 400 \u0026\u0026 requestUrl.indexOf(\u0027/api/audit/\u0027) !== -1) {",
+                                                  "  pm.test(\u0027hardening: audit 400 has structured error body\u0027, function(){",
+                                                  "    var body = safeJson();",
+                                                  "    if (body \u0026\u0026 typeof body === \u0027object\u0027) {",
+                                                  "      pm.expect(hasStructuredError(body)).to.eql(true);",
+                                                  "    }",
+                                                  "  });",
+                                                  "}",
+                                                  "if (requestUrl.indexOf(\u0027/api/auth/login\u0027) !== -1 \u0026\u0026 code === 401) {",
+                                                  "  pm.test(\u0027hardening: auth login 401 message contract\u0027, function(){",
+                                                  "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf(\u0027invalid credentials\u0027) !== -1 || x.indexOf(\u0027email not confirmed\u0027) !== -1; });",
+                                                  "  });",
+                                                  "}",
+                                                  "if (requestUrl.indexOf(\u0027/api/auth/login\u0027) !== -1 \u0026\u0026 code === 423) {",
+                                                  "  pm.test(\u0027hardening: auth login 423 message contract\u0027, function(){",
+                                                  "    pm.expect(textLower).to.include(\u0027account is locked\u0027);",
+                                                  "  });",
+                                                  "}",
+                                                  "if (requestUrl.indexOf(\u0027/api/auth/google\u0027) !== -1 \u0026\u0026 code === 400) {",
+                                                  "  pm.test(\u0027hardening: google login 400 message contract\u0027, function(){",
+                                                  "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf(\u0027invalid google token\u0027) !== -1 || x.indexOf(\u0027google login failed\u0027) !== -1; });",
+                                                  "  });",
+                                                  "}",
+                                                  "if (requestUrl.indexOf(\u0027/api/vaults/\u0027) !== -1 \u0026\u0026 requestUrl.indexOf(\u0027/share\u0027) !== -1 \u0026\u0026 code === 404) {",
+                                                  "  pm.test(\u0027hardening: vault share 404 message contract when body exists\u0027, function(){",
+                                                  "    if (rawText.length === 0) { return; }",
+                                                  "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf(\u0027vault not found\u0027) !== -1 || x.indexOf(\u0027target user not found\u0027) !== -1 || x.indexOf(\u0027share not found\u0027) !== -1; });",
+                                                  "  });",
+                                                  "}",
+                                                  "if (requestUrl.indexOf(\u0027/api/invitations\u0027) !== -1 \u0026\u0026 (code === 400 || code === 404)) {",
+                                                  "  pm.test(\u0027hardening: invitation error message contract\u0027, function(){",
+                                                  "    pm.expect(textLower).to.satisfy(function(x){ return x.indexOf(\u0027invitation\u0027) !== -1 || x.indexOf(\u0027vault not found\u0027) !== -1 || x.indexOf(\u0027invalid role\u0027) !== -1 || x.indexOf(\u0027different email address\u0027) !== -1 || x.indexOf(\u0027not found\u0027) !== -1 || x.indexOf(\u0027permission\u0027) !== -1; });",
+                                                  "  });",
+                                                  "}"
+                                              ]
+                                 }
+                  }
+              ],
+    "item":  [
+                 {
+                     "name":  "Auth",
+                     "item":  [
+                                  {
+                                      "name":  "Auth - Register (201)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.environment.set(\u0027timestamp\u0027, Date.now());",
+                                                                                    "pm.environment.set(\u0027userEmail\u0027, \u0027smoke+\u0027 + pm.environment.get(\u0027timestamp\u0027) + \u0027@test.local\u0027);"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027201 Created\u0027, function(){ pm.response.to.have.status(201); });",
+                                                                                    "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r \u0026\u0026 r.user) pm.environment.set(\u0027userId\u0027, r.user.id || r.user.Id || \u0027\u0027); if(r \u0026\u0026 r.accessToken) pm.environment.set(\u0027accessToken\u0027, r.accessToken || r.AccessToken || \u0027\u0027); }catch(e){} }"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{\n  \"email\": \"smoke+{{timestamp}}@test.local\",\n  \"password\": \"{{userPassword}}\",\n  \"confirmPassword\": \"{{userPassword}}\",\n  \"userName\": \"smokeuser{{timestamp}}\"\n}"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/register",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "register"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Register Missing Email (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });",
+                                                                                    "pm.test(\u0027contains email\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027email\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"password\": \"Password1!\", \"confirmPassword\": \"Password1!\", \"userName\": \"x\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/register",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "register"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Register Password Mismatch (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });",
+                                                                                    "pm.test(\u0027contains password mismatch/validation message\u0027, function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027password\u0027) || x.includes(\u0027confirm\u0027) || x.includes(\u0027match\u0027) || x.includes(\u0027validation\u0027); }); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"badpw+{{timestamp}}@test.local\", \"password\": \"Password1!\", \"confirmPassword\": \"Different1!\", \"userName\": \"x\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/register",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "register"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Login (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });",
+                                                                                    "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r \u0026\u0026 r.accessToken) pm.environment.set(\u0027accessToken\u0027, r.accessToken || r.AccessToken || \u0027\u0027); if(r \u0026\u0026 r.user) pm.environment.set(\u0027userId\u0027, r.user.id || r.user.Id || \u0027\u0027); }catch(e){} }"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"{{userEmail}}\", \"password\": \"{{userPassword}}\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/login",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "login"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Login Missing Fields (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/login",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "login"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Login Invalid Credentials (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });",
+                                                                                    "pm.test(\u0027contains invalid credentials message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027invalid credentials\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"no-such-user@test.local\", \"password\": \"wrong\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/login",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "login"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Login Locked (423)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "var baseUrl = pm.variables.get(\u0027baseUrl\u0027);",
+                                                                                    "var email = pm.variables.get(\u0027userEmail\u0027);",
+                                                                                    "var wrongPassword = \u0027WrongLockout123!\u0027;",
+                                                                                    "for (var i = 0; i \u003c 5; i++) {",
+                                                                                    "  pm.sendRequest({",
+                                                                                    "    url: baseUrl + \u0027/api/auth/login\u0027,",
+                                                                                    "    method: \u0027POST\u0027,",
+                                                                                    "    header: { \u0027Content-Type\u0027: \u0027application/json\u0027 },",
+                                                                                    "    body: { mode: \u0027raw\u0027, raw: JSON.stringify({ email: email, password: wrongPassword }) }",
+                                                                                    "  }, function () {});",
+                                                                                    "}"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 or 423 while lockout state settles\u0027, function(){ pm.expect([401,423]).to.include(pm.response.code); });",
+                                                                                    "pm.test(\u0027contains invalid credentials or account locked message\u0027, function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027invalid credentials\u0027) || x.includes(\u0027account is locked\u0027); }); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"{{userEmail}}\", \"password\": \"wrong1\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/login",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "login"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Google Invalid Token (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });",
+                                                                                    "pm.test(\u0027contains google token error message\u0027, function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027invalid google token\u0027) || x.includes(\u0027google login failed\u0027); }); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"idToken\": \"invalid-token\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/google",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "google"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Me Get Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/me",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "me"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Me Get (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/me",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "me"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Update Profile Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"userName\": \"x\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/me",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "me"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Update Profile BadRequest (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });",
+                                                                                    "pm.test(\u0027contains email validation\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027email\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"not-an-email\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/me",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "me"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Update Profile (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"userName\": \"updated-{{timestamp}}\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/me",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "me"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Delete Account Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/me",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "me"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Delete Account NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "var baseUrl = pm.variables.get(\u0027baseUrl\u0027);",
+                                                                                    "var ts = Date.now();",
+                                                                                    "var email = \u0027deleted+\u0027 + ts + \u0027@test.local\u0027;",
+                                                                                    "var password = pm.variables.get(\u0027userPassword\u0027) || \u0027Password1!\u0027;",
+                                                                                    "var registerPayload = { email: email, password: password, confirmPassword: password, userName: \u0027deleted\u0027 + ts };",
+                                                                                    "pm.sendRequest({",
+                                                                                    "  url: baseUrl + \u0027/api/auth/register\u0027,",
+                                                                                    "  method: \u0027POST\u0027,",
+                                                                                    "  header: { \u0027Content-Type\u0027: \u0027application/json\u0027 },",
+                                                                                    "  body: { mode: \u0027raw\u0027, raw: JSON.stringify(registerPayload) }",
+                                                                                    "}, function (err, res) {",
+                                                                                    "  if (err || !res || res.code !== 201) { return; }",
+                                                                                    "  var body = {};",
+                                                                                    "  try { body = res.json(); } catch (e) {}",
+                                                                                    "  var token = body.accessToken || \u0027\u0027;",
+                                                                                    "  if (!token) { return; }",
+                                                                                    "  pm.environment.set(\u0027deletedAccessToken\u0027, token);",
+                                                                                    "  pm.sendRequest({",
+                                                                                    "    url: baseUrl + \u0027/api/auth/me\u0027,",
+                                                                                    "    method: \u0027DELETE\u0027,",
+                                                                                    "    header: { Authorization: \u0027Bearer \u0027 + token }",
+                                                                                    "  }, function () {});",
+                                                                                    "});"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains user not found message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027user not found\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{deletedAccessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/me",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "me"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Permissions Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/permissions",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "permissions"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Permissions (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/permissions",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "permissions"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Assign Role Forbidden (403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 Forbidden\u0027, function(){ pm.response.to.have.status(403); });",
+                                                                                    "pm.test(\u0027forbidden/unauthorized message present\u0027, function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes(\u0027forbid\u0027) || x.includes(\u0027forbidden\u0027) || x.length === 0; }); } else { pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes(\u0027unauthorized\u0027) || x.length === 0; }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"userId\": 999999, \"role\": \"Admin\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/assign-role",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "assign-role"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Assign Role BadRequest (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });",
+                                                                                    "pm.test(\u0027contains role does not exist message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027does not exist\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{adminUserId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"userId\": {{userId}}, \"role\": \"NonExistentRole\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/assign-role",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "assign-role"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Assign Role NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains user not found message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027user not found\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{adminUserId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"userId\": 999999, \"role\": \"Admin\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/assign-role",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "assign-role"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Assign Role (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{adminUserId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"userId\": {{userId}}, \"role\": \"VaultOwner\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/assign-role",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "assign-role"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Auth - Assign Role Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer invalid_token"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"userId\": {{userId}}, \"role\": \"User\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/auth/assign-role",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "auth",
+                                                                               "assign-role"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Users",
+                     "item":  [
+                                  {
+                                      "name":  "Users - List Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - List Forbidden (403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 Forbidden\u0027, function(){ pm.response.to.have.status(403); });",
+                                                                                    "pm.test(\u0027if 403 then forbidden message\u0027, function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes(\u0027forbid\u0027) || x.includes(\u0027forbidden\u0027) || x.length === 0; }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - List (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027if 403 then forbidden message\u0027, function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes(\u0027forbid\u0027) || x.includes(\u0027forbidden\u0027) || x.length === 0; }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{adminUserId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/{{userId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "{{userId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get Forbidden/NotFound (403|404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 Forbidden\u0027, function(){ pm.response.to.have.status(403); });",
+                                                                                    "pm.test(\u0027contains expected get-user error message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include(\u0027user not found\u0027); } else { pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027forbid\u0027) || x.includes(\u0027forbidden\u0027) || x.length === 0; }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 Forbidden\u0027, function(){ pm.response.to.have.status(403); });",
+                                                                                    "pm.test(\u0027contains forbidden message when present\u0027, function(){ var t = pm.response.text().toLowerCase(); if(t.length \u003e 0){ pm.expect(t).to.include(\u0027permission\u0027); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/{{userId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "{{userId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Update Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"x\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/{{userId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "{{userId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Update BadRequest (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"not-an-email\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/{{userId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "{{userId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Update Forbidden/NotFound (403|404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 Forbidden\u0027, function(){ pm.response.to.have.status(403); });",
+                                                                                    "pm.test(\u0027contains expected update-user error message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include(\u0027user not found\u0027); } else { pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027forbid\u0027) || x.includes(\u0027forbidden\u0027) || x.length === 0; }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"x@test.local\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Update (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });",
+                                                                                    "pm.environment.set(\u0027userEmail\u0027, \u0027updated+\u0027 + pm.environment.get(\u0027timestamp\u0027) + \u0027@test.local\u0027);"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"updated+{{timestamp}}@test.local\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/{{userId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "{{userId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Delete Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/{{userId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "{{userId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Delete Forbidden/NotFound (403|404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 Forbidden\u0027, function(){ pm.response.to.have.status(403); });",
+                                                                                    "pm.test(\u0027contains expected delete-user error message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include(\u0027user not found\u0027); } else { pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027forbid\u0027) || x.includes(\u0027forbidden\u0027) || x.length === 0; }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get Vaults Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/{{userId}}/vaults",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "{{userId}}",
+                                                                               "vaults"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get Vaults Forbidden/NotFound (403|404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 Forbidden\u0027, function(){ pm.response.to.have.status(403); });",
+                                                                                    "pm.test(\u0027contains expected get-vaults error message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include(\u0027user not found\u0027); } else { pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027forbid\u0027) || x.includes(\u0027forbidden\u0027) || x.length === 0; }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/999999/vaults",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "999999",
+                                                                               "vaults"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get Vaults Forbidden (403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 Forbidden\u0027, function(){ pm.response.to.have.status(403); });",
+                                                                                    "pm.test(\u0027contains forbidden message when present\u0027, function(){ var t = pm.response.text().toLowerCase(); if(t.length \u003e 0){ pm.expect(t).to.include(\u0027permission\u0027); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/999999/vaults",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "999999",
+                                                                               "vaults"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get Vaults (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/{{userId}}/vaults",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "{{userId}}",
+                                                                               "vaults"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get Tags Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/{{userId}}/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "{{userId}}",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get Tags Forbidden/NotFound (403|404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 Forbidden\u0027, function(){ pm.response.to.have.status(403); });",
+                                                                                    "pm.test(\u0027contains expected get-tags error message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include(\u0027user not found\u0027); } else { pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027forbid\u0027) || x.includes(\u0027forbidden\u0027) || x.length === 0; }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/999999/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "999999",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get Tags Forbidden (403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 Forbidden\u0027, function(){ pm.response.to.have.status(403); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/999999/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "999999",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Users - Get Tags (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/user/{{userId}}/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "user",
+                                                                               "{{userId}}",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Vaults",
+                     "item":  [
+                                  {
+                                      "name":  "Vaults - Create Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"noauth\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Vaults - Create BadRequest (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });",
+                                                                                    "pm.test(\u0027contains validation details\u0027, function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027validation\u0027) || x.includes(\u0027errors\u0027) || x.includes(\u0027required\u0027) || x.includes(\u0027invalid or unauthorized tag ids\u0027); }); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Vaults - Create (201)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027201 Created\u0027, function(){ pm.response.to.have.status(201); });",
+                                                                                    "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r \u0026\u0026 r.id) pm.environment.set(\u0027vaultId\u0027, r.id); }catch(e){} }"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"Smoke Vault {{timestamp}}\", \"userId\": {{userId}} }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Vaults - List (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Vaults - Get (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Vaults - Update (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"Updated Vault {{timestamp}}\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Vaults - Create For Deletion (201)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027201 Created\u0027, function(){ pm.response.to.have.status(201); });",
+                                                                                    "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r \u0026\u0026 r.id) pm.environment.set(\u0027deleteVaultId\u0027, r.id); }catch(e){} }"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"TempDeleteVault {{timestamp}}\", \"userId\": {{userId}} }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Vaults - Delete (204)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027204 NoContent\u0027, function(){ pm.response.to.have.status(204); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{deleteVaultId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{deleteVaultId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Vaults - Delete NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains vault not found message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027vault not found\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/999998",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "999998"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Credentials",
+                     "item":  [
+                                  {
+                                      "name":  "Credentials - List Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/1/credentials",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "1",
+                                                                               "credentials"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - List Forbidden/NotFound (403|404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 or 404 (vault does not belong to user or does not exist)\u0027, function(){ pm.expect(pm.response.code).to.be.oneOf([403, 404]); });",
+                                                                                    "pm.test(\u0027contains expected list-credentials error message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 403){ pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027forbid\u0027) || x.includes(\u0027forbidden\u0027) || x.length === 0; }); } else { pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027not found\u0027) || x.length === 0; }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/999999/credentials",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "999999",
+                                                                               "credentials"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - List (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "credentials"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Create Missing Password (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"title\": \"NoPass\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "credentials"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Create NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains vault not found message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027vault not found\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"title\": \"NoPerm\", \"encryptedPassword\": \"x\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/999999/credentials",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "999999",
+                                                                               "credentials"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Create (201)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027201 Created\u0027, function(){ pm.response.to.have.status(201); });",
+                                                                                    "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r \u0026\u0026 r.id) pm.environment.set(\u0027credentialId\u0027, r.id); }catch(e){} }"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"title\": \"Smoke Credential {{timestamp}}\", \"encryptedPassword\": \"s3cret\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "credentials"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Get Password Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/1/password",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "1",
+                                                                               "password"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Get Password NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/999999/password",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "999999",
+                                                                               "password"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Get Password Forbidden/NotFound (403|404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}/password",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}",
+                                                                               "password"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Get Password (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027has password\u0027, function(){ try{ var j = JSON.parse(pm.response.text()); pm.expect(j).to.have.property(\u0027password\u0027); }catch(e){ pm.expect.fail(\u0027response not json or empty\u0027); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}/password",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}",
+                                                                               "password"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Get By Id Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\"401 Unauthorized\", function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/1",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "1"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Get By Id NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\"404 Not Found\", function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Get By Id (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\"200 OK\", function(){ pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\"has credential fields\", function(){ var j = pm.response.json(); pm.expect(j).to.have.property(\"id\"); pm.expect(j).to.have.property(\"title\"); pm.expect(j).to.have.property(\"vaultId\"); pm.expect(j).to.have.property(\"tags\"); pm.expect(j.tags).to.be.an(\"array\"); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Update Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"title\": \"x\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/1",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "1"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Update NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"title\": \"x\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Update Forbidden (403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027204 NoContent\u0027, function(){ pm.response.to.have.status(204); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"title\": \"x\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Update BadRequest (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Update (204)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027204 NoContent\u0027, function(){ pm.response.to.have.status(204); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"title\": \"Updated Title {{timestamp}}\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Update Password BadRequest (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}/password",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}",
+                                                                               "password"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Update Password (204)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027204 NoContent\u0027, function(){ pm.response.to.have.status(204); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"encryptedPassword\": \"newpass\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}/password",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}",
+                                                                               "password"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Delete Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/1",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "1"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Delete NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Delete NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains credential not found message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027credential not found\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/999998",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "999998"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Create For Deletion (201)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027201 Created\u0027, function(){ pm.response.to.have.status(201); });",
+                                                                                    "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r \u0026\u0026 r.id) pm.environment.set(\u0027deleteCredentialId\u0027, r.id); }catch(e){} }"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"title\": \"TempDeleteCred {{timestamp}}\", \"encryptedPassword\": \"s3cret\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/credentials",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "credentials"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Delete (204)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027204 NoContent\u0027, function(){ pm.response.to.have.status(204); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{deleteCredentialId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{deleteCredentialId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Get Tags Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/1/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "1",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Get Tags NotFound/Forbidden (404|403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains expected get-tags error message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027credential not found\u0027) || x.includes(\u0027not found\u0027); }); } else { pm.expect(t).to.include(\u0027permission\u0027); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/999997/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "999997",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Get Tags (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Setup Create Tag (201)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027201 Created\u0027, function(){ pm.response.to.have.status(201); });",
+                                                                                    "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r \u0026\u0026 r.id) pm.environment.set(\u0027credTagId\u0027, r.id); }catch(e){} }"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"cred-tag-{{timestamp}}\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Set Tags BadRequest (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"tagIds\": [999999] }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Set Tags (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027returns array of tags\u0027, function(){ pm.expect(pm.response.json()).to.be.an(\u0027array\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"tagIds\": [{{credTagId}}] }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Add Tag BadRequest/NotFound (400|404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains expected add-tag error message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027tag not found\u0027) || x.includes(\u0027credential not found\u0027); }); } else { pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027tag does not belong\u0027) || x.includes(\u0027already assigned\u0027); }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}/tags/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}",
+                                                                               "tags",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Setup Create Second Tag (201)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027201 Created\u0027, function(){ pm.response.to.have.status(201); });",
+                                                                                    "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r \u0026\u0026 r.id) pm.environment.set(\u0027credTagId2\u0027, r.id); }catch(e){} }"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"cred-tag2-{{timestamp}}\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Add Tag (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027returns tag added message\u0027, function(){ var b = pm.response.json(); pm.expect(b).to.have.property(\u0027message\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}/tags/{{credTagId2}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}",
+                                                                               "tags",
+                                                                               "{{credTagId2}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Remove Tag NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains tag assignment not found message\u0027, function(){ var t = pm.response.text().toLowerCase(); pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027not assigned to this credential\u0027) || x.includes(\u0027credential not found\u0027); }); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}/tags/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}",
+                                                                               "tags",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Remove Tag CredentialNotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains credential not found message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027credential not found\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/999999/tags/1",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "999999",
+                                                                               "tags",
+                                                                               "1"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Credentials - Remove Tag (204)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027204 NoContent\u0027, function(){ pm.response.to.have.status(204); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/credentials/{{credentialId}}/tags/{{credTagId2}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "credentials",
+                                                                               "{{credentialId}}",
+                                                                               "tags",
+                                                                               "{{credTagId2}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Tags",
+                     "item":  [
+                                  {
+                                      "name":  "Tags - List Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - List (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Get Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags/{{tagId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags",
+                                                                               "{{tagId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Get NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains not found message when present\u0027, function(){ var t = pm.response.text().toLowerCase(); if(t.length \u003e 0){ pm.expect(t).to.include(\u0027not found\u0027); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Get (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags/{{tagId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags",
+                                                                               "{{tagId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Create Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"noauth\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Create BadRequest (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Create (201)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027201 Created\u0027, function(){ pm.response.to.have.status(201); });",
+                                                                                    "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r \u0026\u0026 r.id) pm.environment.set(\u0027tagId\u0027, r.id); }catch(e){} }"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"smoke-tag-{{timestamp}}\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Create Duplicate (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });",
+                                                                                    "pm.test(\u0027contains duplicate tag message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027already exists\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"smoke-tag-{{timestamp}}\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Update Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"x\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags/1",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags",
+                                                                               "1"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Update NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"x\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Setup Create Conflict Tag",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "// 201 on first run, 400 if tag already exists â€” both are fine"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"existing-name\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Update Forbidden or BadRequest (403|400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });",
+                                                                                    "pm.test(\u0027contains duplicate tag message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027already exists\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"existing-name\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags/{{tagId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags",
+                                                                               "{{tagId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Update (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "PUT",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"name\": \"renamed-{{timestamp}}\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags/{{tagId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags",
+                                                                               "{{tagId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Delete Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags/1",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags",
+                                                                               "1"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Delete NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Delete Forbidden (403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags/999998",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags",
+                                                                               "999998"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Tags - Delete (204)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027204 NoContent\u0027, function(){ pm.response.to.have.status(204); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/tags/{{tagId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "tags",
+                                                                               "{{tagId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Invitations",
+                     "item":  [
+                                  {
+                                      "name":  "Invitations - Create Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"invitee@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"View\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Create VaultNotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"invitee@test.local\", \"vaultId\": 999999, \"role\": \"View\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Create Forbid (403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027201 Created\u0027, function(){ pm.response.to.have.status(201); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"invitee@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"View\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Create BadRequest (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"invitee+{{timestamp}}@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"NotARole\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Create (201)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027201 Created\u0027, function(){ pm.response.to.have.status(201); });",
+                                                                                    "var txt = pm.response.text(); if(txt){ try{ var r = JSON.parse(txt); if(r \u0026\u0026 r.id) pm.environment.set(\u0027invitationId\u0027, r.id); if(r \u0026\u0026 r.inviteToken) pm.environment.set(\u0027inviteToken\u0027, r.inviteToken); }catch(e){} }"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"email\": \"invitee+{{timestamp}}@test.local\", \"vaultId\": {{vaultId}}, \"role\": \"View\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - List Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - List (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Accept Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations/invalid_token/accept",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations",
+                                                                               "invalid_token",
+                                                                               "accept"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Accept NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations/no-such-token/accept",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations",
+                                                                               "no-such-token",
+                                                                               "accept"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Accept BadRequest (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });",
+                                                                                    "pm.test(\u0027contains invitation mismatch/not found message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include(\u0027invitation not found\u0027); } else { pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027different email address\u0027) || x.includes(\u0027cannot\u0027); }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations/{{inviteToken}}/accept",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations",
+                                                                               "{{inviteToken}}",
+                                                                               "accept"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Accept (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027400 BadRequest\u0027, function(){ pm.response.to.have.status(400); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations/{{inviteToken}}/accept",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations",
+                                                                               "{{inviteToken}}",
+                                                                               "accept"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Revoke Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations/1",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations",
+                                                                               "1"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Revoke NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains not found message when present\u0027, function(){ var t = pm.response.text().toLowerCase(); if(t.length \u003e 0){ pm.expect(t).to.include(\u0027not found\u0027); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Revoke Forbidden (403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations/999998",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations",
+                                                                               "999998"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Invitations - Revoke (204)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027204 NoContent\u0027, function(){ pm.response.to.have.status(204); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/invitations/{{invitationId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "invitations",
+                                                                               "{{invitationId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "VaultShares",
+                     "item":  [
+                                  {
+                                      "name":  "VaultShares - Share Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"userEmail\": \"noone@test.local\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/share",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "share"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "VaultShares - Share BadRequest (400)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/share",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "share"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "VaultShares - Share NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"userEmail\": \"noone@test.local\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/999999/share",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "999999",
+                                                                               "share"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "VaultShares - Share Forbidden (403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"userEmail\": \"noone@test.local\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/share",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "share"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "VaultShares - Share (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027404 contains target user not found message\u0027, function(){ if(pm.response.code === 404){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes(\u0027target user not found\u0027) || x.includes(\u0027vault not found\u0027); }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json"
+                                                                     },
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{ \"userEmail\": \"invitee+{{timestamp}}@test.local\" }"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/share",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "share"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "VaultShares - Revoke Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/share/{{userId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "share",
+                                                                               "{{userId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "VaultShares - Revoke NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains share not found message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes(\u0027share not found\u0027) || x.includes(\u0027vault not found\u0027); }); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/share/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "share",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "VaultShares - Revoke Forbidden (403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/share/{{userId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "share",
+                                                                               "{{userId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "VaultShares - Revoke (204)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "var baseUrl = pm.variables.get(\u0027baseUrl\u0027);",
+                                                                                    "var vaultId = pm.variables.get(\u0027vaultId\u0027);",
+                                                                                    "var ownerEmail = pm.variables.get(\u0027userEmail\u0027);",
+                                                                                    "var ownerId = pm.variables.get(\u0027userId\u0027);",
+                                                                                    "pm.sendRequest({",
+                                                                                    "  url: baseUrl + \u0027/api/vaults/\u0027 + vaultId + \u0027/share\u0027,",
+                                                                                    "  method: \u0027POST\u0027,",
+                                                                                    "  header: { \u0027Content-Type\u0027: \u0027application/json\u0027, \u0027X-UserId\u0027: String(ownerId) },",
+                                                                                    "  body: { mode: \u0027raw\u0027, raw: JSON.stringify({ userEmail: ownerEmail }) }",
+                                                                                    "}, function () {});"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027204 NoContent\u0027, function(){ pm.response.to.have.status(204); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "DELETE",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/vaults/{{vaultId}}/share/{{userId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "vaults",
+                                                                               "{{vaultId}}",
+                                                                               "share",
+                                                                               "{{userId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Audit",
+                     "item":  [
+                                  {
+                                      "name":  "Audit - Get My Logs Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Audit - Get My Logs (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Audit - Get Log By Id Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs/1",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs",
+                                                                               "1"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Audit - Get Log By Id Forbidden/NotFound (403|404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 or 404 (log belongs to another user or does not exist)\u0027, function(){ pm.expect(pm.response.code).to.be.oneOf([403, 404]); });",
+                                                                                    "pm.test(\u0027contains expected get-log-by-id error message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(pm.response.code === 404){ pm.expect(t).to.include(\u0027audit log not found\u0027); } else { pm.expect(t).to.satisfy(function(x){ return x.includes(\u0027forbid\u0027) || x.includes(\u0027forbidden\u0027) || x.length === 0; }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Audit - Get Log By Id NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains audit log not found error message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(t.length \u003e 0){ pm.expect(t).to.include(\u0027audit log not found\u0027); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Audit - Get Vault Logs Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs/vault/{{vaultId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs",
+                                                                               "vault",
+                                                                               "{{vaultId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Audit - Get Vault Logs NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains vault not found message\u0027, function(){ pm.expect(pm.response.text().toLowerCase()).to.include(\u0027vault not found\u0027); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs/vault/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs",
+                                                                               "vault",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Audit - Get Vault Logs NotFound (404)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027404 NotFound\u0027, function(){ pm.response.to.have.status(404); });",
+                                                                                    "pm.test(\u0027contains vault not found error message\u0027, function(){ var t = pm.response.text().toLowerCase(); if(t.length \u003e 0){ pm.expect(t).to.include(\u0027vault not found\u0027); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs/vault/999999",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs",
+                                                                               "vault",
+                                                                               "999999"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Audit - Get Vault Logs (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Authorization",
+                                                                         "value":  "Bearer {{accessToken}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs/vault/{{vaultId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs",
+                                                                               "vault",
+                                                                               "{{vaultId}}"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Audit - Get All Logs Unauthorized (401)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027401 Unauthorized\u0027, function(){ pm.response.to.have.status(401); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs/all",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs",
+                                                                               "all"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Audit - Get All Logs (200)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027200 OK\u0027, function(){ pm.response.to.have.status(200); });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{adminUserId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs/all",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs",
+                                                                               "all"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  },
+                                  {
+                                      "name":  "Audit - Get All Logs Forbidden (403)",
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027403 Forbidden\u0027, function(){ pm.response.to.have.status(403); });",
+                                                                                    "pm.test(\u0027if 403 then forbidden message\u0027, function(){ if(pm.response.code === 403){ pm.expect(pm.response.text().toLowerCase()).to.satisfy(function(x){ return x.includes(\u0027forbid\u0027) || x.includes(\u0027forbidden\u0027) || x.length === 0; }); } });"
+                                                                                ],
+                                                                       "type":  "text/javascript"
+                                                                   }
+                                                    }
+                                                ],
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "X-UserId",
+                                                                         "value":  "{{userId}}"
+                                                                     }
+                                                                 ],
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/audit/logs/all",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "audit",
+                                                                               "logs",
+                                                                               "all"
+                                                                           ]
+                                                              }
+                                                  },
+                                      "response":  [
+
+                                                   ]
+                                  }
+                              ]
+                 }
+             ],
+    "variable":  [
+                     {
+                         "key":  "baseUrl",
+                         "value":  "http://localhost:5246"
+                     },
+                     {
+                         "key":  "timestamp",
+                         "value":  ""
+                     },
+                     {
+                         "key":  "userEmail",
+                         "value":  ""
+                     },
+                     {
+                         "key":  "userPassword",
+                         "value":  "Password1!"
+                     },
+                     {
+                         "key":  "userId",
+                         "value":  ""
+                     },
+                     {
+                         "key":  "accessToken",
+                         "value":  ""
+                     },
+                     {
+                         "key":  "adminUserId",
+                         "value":  "1"
+                     },
+                     {
+                         "key":  "vaultId",
+                         "value":  ""
+                     },
+                     {
+                         "key":  "credentialId",
+                         "value":  ""
+                     },
+                     {
+                         "key":  "tagId",
+                         "value":  ""
+                     },
+                     {
+                         "key":  "invitationId",
+                         "value":  ""
+                     }
+                 ]
 }
-
-
-


### PR DESCRIPTION
Closes #180. Implements the professor's requirement: *"Both JSON and XML for everything, DOCUMENT ON HOW TO SEND XML."*

## Verification first
I probed **every endpoint** live with `Accept: application/xml`. Many returned JSON because `XmlSerializer` can't serialize certain shapes:

| Bucket | Endpoints affected | Cause |
|---|---|---|
| Positional records | `/api/tags`, `/api/tags/{id}`, `/api/credentials/{id}/tags`, `/api/user/{id}/tags`, `/api/user/{id}/vaults` | `TagDto`/`VaultSummaryDto` had no parameterless ctor |
| Anonymous types | `/api/vaults/{id}/credentials`, `/api/credentials/{id}/password`, create-credential, add-tag, accept-invitation, assign-role | anonymous types aren't serializable |
| Interface member | `/api/audit/logs`, `/api/audit/logs/all` | `PaginatedAuditResult.Items` was `IEnumerable<T>` |
| Lazy `IEnumerable` | `/api/user`, `/api/invitations` | `.Select(...)` not materialized |

## Fix
- `TagDto`, `VaultSummaryDto`: positional record → class with a parameterless ctor (kept the positional ctor so all call sites and EF projections are unchanged).
- Anonymous bodies → named DTOs: `CredentialListItemDto`, `PasswordResponse`, `IdResponse`, `MessageResponse`, `InvitationAcceptedResponse`.
- `PaginatedAuditResult.Items`: `IEnumerable<AuditLogDto>` → `List<AuditLogDto>` (+ `AuditManager` `.ToList()`).
- `GetAllUsers` / `ListInvitations`: materialize with `.ToList()`.

JSON shapes are unchanged (camelCase, same field names). XML uses PascalCase element names per `XmlSerializer`.

## Docs
- `docs/XML.md` — how to send/receive XML, curl examples (request + response), and gotchas; linked from the README.

## Verification after
- Re-probed all endpoints → every one returns `application/xml` (correct root elements) and JSON stays the default.
- New tests: tags list, credentials list + password, audit logs → all `application/xml`.
- `docker compose --profile test run --rm test` → **112/112 pass**.

Note: error-body XML negotiation is delivered separately by #178 (PR #183); `docs/XML.md` flags this in the errors section.