### PR TITLE
fix: dedicated least-privilege MySQL account instead of root (#179)

### DIFF
--- a/PassManAPI/Program.cs
+++ b/PassManAPI/Program.cs
@@ -272,7 +272,7 @@ public class Program
         {
             // Call DB to test the connectivity
             var conn = builder.Configuration.GetConnectionString("DefaultConnection")
-                       ?? "Server=db;Port=3306;Database=passManDB;User=root;Password=hihi";
+                       ?? "Server=db;Port=3306;Database=passManDB;User=passman_app;Password=passman_app_dev_pw";
             await SqlTest.RunAsync(conn);
         }
 

--- a/PassManAPI/appsettings.Development.json
+++ b/PassManAPI/appsettings.Development.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Port=3306;Database=passManDB;User=root;Password=hihi;Pooling=true"
+    "DefaultConnection": "Server=localhost;Port=3306;Database=passManDB;User=passman_app;Password=passman_app_dev_pw;Pooling=true"
   },
   "Jwt": {
     "Issuer": "PassManAPI",

--- a/PassManAPI/appsettings.json
+++ b/PassManAPI/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=db;Database=passManDB;User=root;Password=hihi;"
+    "DefaultConnection": "Server=db;Database=passManDB;User=passman_app;Password=passman_app_dev_pw;"
   },
   "Jwt": {
     "Issuer": "PassManAPI",

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ dotnet test --filter "FullyQualifiedName~AuthEndpointsTests"
 - **[BACKUP_RECOVERY.md](/BACKUP_RECOVERY.md)** - Database backup procedures
 - **[ProjectSummary.md](/ProjectSummary.md)** - Feature breakdown and roadmap
 - **[GOOGLE_AUTH_DOCS.md](/GOOGLE_AUTH_DOCS.md)** - OAuth setup guide
+- **[docs/DATABASE.md](docs/DATABASE.md)** - Dedicated least-privilege DB account & provisioning
 - **Swagger UI**: http://localhost:5246/swagger
 
 ## 🎯 Current Features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:8080
       - DOTNET_USE_POLLING_FILE_WATCHER=true
-      - ConnectionStrings__DefaultConnection=Server=db;Port=3306;Database=passManDB;User=root;Password=hihi;Pooling=true
+      - ConnectionStrings__DefaultConnection=Server=db;Port=3306;Database=passManDB;User=passman_app;Password=${DB_APP_PASSWORD:-passman_app_dev_pw};Pooling=true
       - Jwt__SigningKey=${JWT_SIGNING_KEY:-dev-only-signing-key-change-me-32chars}
     command: dotnet watch --project PassManAPI.csproj run --urls http://0.0.0.0:8080
     volumes:
@@ -66,11 +66,19 @@ services:
   db:
    image: mysql:8.0
    container_name: db
+   # MySQL 8.0 enables binary logging by default, which would otherwise require SUPER for the
+   # non-root app account to create the startup trigger/stored procedures (see DatabaseArtifacts).
+   command: --log-bin-trust-function-creators=1
    ports:
      - "3306:3306"
    environment:
      - MYSQL_ROOT_PASSWORD=hihi
      - MYSQL_DATABASE=passManDB
+     # Dedicated least-privilege application account. The MySQL image grants this user ALL
+     # privileges on passManDB only (no other databases, no server-admin rights). The API uses it
+     # instead of root; root stays for DB administration / the healthcheck.
+     - MYSQL_USER=passman_app
+     - MYSQL_PASSWORD=${DB_APP_PASSWORD:-passman_app_dev_pw}
    volumes:
      - mysql-data:/var/lib/mysql
    healthcheck:

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,0 +1,78 @@
+# Database Account & Access
+
+The API connects to MySQL with a **dedicated, least-privilege account** (`passman_app`) rather than
+`root`. The account is scoped to the application's own database and has no server-wide or
+administrative rights.
+
+> This is the **database login** the API authenticates with — distinct from the application's
+> in-app RBAC (Admin / VaultOwner / etc.), which is documented separately (see #166).
+
+## The account
+
+| | |
+|---|---|
+| User | `passman_app` (host `%`) |
+| Password | `DB_APP_PASSWORD` env var, default `passman_app_dev_pw` (dev only) |
+| Grants | `GRANT ALL PRIVILEGES ON passManDB.*` — and nothing else |
+| Cannot | access other databases, read the `mysql` system schema, or `GRANT` to others |
+
+`root` is kept only for DB administration and the container healthcheck; the application never uses it.
+
+Verify on a running stack:
+
+```bash
+docker compose exec db mysql -upassman_app -ppassman_app_dev_pw -e "SELECT CURRENT_USER(); SHOW GRANTS;"
+# CURRENT_USER() -> passman_app@%
+# GRANT USAGE ON *.* ...
+# GRANT ALL PRIVILEGES ON `passManDB`.* ...
+```
+
+## How it's provisioned (Docker)
+
+The MySQL image creates the user automatically on **first initialization** from the `db` service env
+in `docker-compose.yml`:
+
+```yaml
+environment:
+  - MYSQL_DATABASE=passManDB
+  - MYSQL_USER=passman_app
+  - MYSQL_PASSWORD=${DB_APP_PASSWORD:-passman_app_dev_pw}
+```
+
+The image grants `MYSQL_USER` full privileges on `MYSQL_DATABASE` only. Because this runs only when the
+data volume is empty, recreate it for a clean account:
+
+```bash
+docker compose down -v && docker compose up -d db passman-api
+```
+
+### Why `--log-bin-trust-function-creators=1`
+
+MySQL 8.0 has binary logging on by default, which normally requires `SUPER` to create triggers or
+stored routines. The app creates a trigger and two stored procedures at startup
+(`Data/DatabaseArtifacts.cs`), so the `db` service sets `--log-bin-trust-function-creators=1`,
+letting the non-`SUPER` `passman_app` account create them. (Without this, the API would fail to start
+as a non-root user.)
+
+## Provisioning on an external / existing MySQL
+
+For a database not created by this compose file (or an existing volume), create the account manually:
+
+```sql
+CREATE USER 'passman_app'@'%' IDENTIFIED BY 'a-strong-password';
+GRANT ALL PRIVILEGES ON passManDB.* TO 'passman_app'@'%';
+FLUSH PRIVILEGES;
+-- if binary logging is enabled and the app account creates the triggers/procedures:
+SET GLOBAL log_bin_trust_function_creators = 1;
+```
+
+Then point the connection string at it via `ConnectionStrings__DefaultConnection`
+(or the `DB_APP_PASSWORD` env var for the compose default).
+
+## Notes & future hardening
+
+- The dev password is committed for zero-config local runs (mirroring the existing root/`hihi`
+  convention). For any real deployment, set `DB_APP_PASSWORD` from a secret store and rotate it.
+- The app self-migrates and creates DB artifacts at startup, so it needs DDL on its own database;
+  `ALL PRIVILEGES ON passManDB.*` is the appropriate scope. If startup migrations/artifacts are ever
+  moved to a separate provisioning step, the runtime account could be narrowed to DML + `EXECUTE`.


### PR DESCRIPTION
Closes #179. Implements the professor's requirement: *"Make sure the api talks with the db with a specific account."*

## Before
The API connected as **root** everywhere — `appsettings.json`, `appsettings.Development.json`, and `docker-compose.yml` all used `User=root;Password=hihi`.

## After
The API authenticates as a dedicated, database-scoped account `passman_app`:
- `docker-compose` `db` service creates it via `MYSQL_USER`/`MYSQL_PASSWORD` — the MySQL image grants `ALL PRIVILEGES ON passManDB.*` and nothing else.
- All connection strings switched to `passman_app` (password overridable via `DB_APP_PASSWORD`).
- `root` is retained only for DB administration and the container healthcheck.
- Added `--log-bin-trust-function-creators=1` to the `db` service so the **non-SUPER** account can create the startup trigger + stored procedures (MySQL 8.0 has binlog on by default).

## Verification (clean `docker compose down -v && up`)
- API migrates and creates the view/procedures/trigger **as `passman_app`** (startup succeeds without root).
- `SELECT CURRENT_USER()` → `passman_app@%`.
- `SHOW GRANTS` → `USAGE ON *.*` + `ALL PRIVILEGES ON passManDB.*` only.
- Visible databases: just `passManDB` (+ info/perf schema).
- Negative check: `SELECT ... FROM mysql.user` → **access denied** (can't reach the system schema).
- `docker compose --profile test run --rm test` → **109/109** (Test env uses SQLite, unaffected).

## Docs
- `docs/DATABASE.md` — the account, its scope, Docker + manual provisioning (`CREATE USER`/`GRANT`), the binlog note, and future hardening (secrets, narrowing to DML if migrations move out of startup). Linked from the README.

Note: keeps app-level RBAC (Admin/VaultOwner/…) separate — that's documented under #166.